### PR TITLE
Adds Ruby 3.2 to the CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,4 @@ workflows:
                 - cimg/ruby:2.7-node
                 - cimg/ruby:3.0-node
                 - cimg/ruby:3.1-node
+                - cimg/ruby:3.2-node


### PR DESCRIPTION
## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

Ruby 3.2 was released on December 25th, 2022.  A few days later CircleCI added a `cimg` built with this Ruby.  Given that this is the latest release of Ruby, it should be included in the CI for the gem.  This PR adds the necessary CircleCI image.

I've runs specs locally against Ruby 3.2 and they pass.