### PR TITLE
Support multi-tenant use of the gem

### DIFF
--- a/lib/ruby/openai/client.rb
+++ b/lib/ruby/openai/client.rb
@@ -2,51 +2,60 @@ module OpenAI
   class Client
     URI_BASE = "https://api.openai.com/".freeze
 
-    def initialize(access_token: nil, organization_id: nil)
-      Ruby::OpenAI.configuration.access_token = access_token if access_token
-      Ruby::OpenAI.configuration.organization_id = organization_id if organization_id
+    NULL_ORGANIZATION_ID = Object.new.freeze
+
+    attr_reader :access_token, :organization_id, :api_version
+
+    def initialize(access_token: nil, organization_id: NULL_ORGANIZATION_ID, api_version: nil)
+      @access_token = access_token || Ruby::OpenAI.configuration.access_token
+      @organization_id = if organization_id == NULL_ORGANIZATION_ID
+                           Ruby::OpenAI.configuration.access_token
+                         else
+                           organization_id
+                         end
+      @api_version = api_version || Ruby::OpenAI.configuration.api_version
     end
 
     def completions(parameters: {})
-      OpenAI::Client.post(path: "/completions", parameters: parameters)
+      post(path: "/completions", parameters: parameters)
     end
 
     def edits(parameters: {})
-      OpenAI::Client.post(path: "/edits", parameters: parameters)
+      post(path: "/edits", parameters: parameters)
     end
 
     def embeddings(parameters: {})
-      OpenAI::Client.post(path: "/embeddings", parameters: parameters)
+      post(path: "/embeddings", parameters: parameters)
     end
 
     def files
-      @files ||= OpenAI::Files.new
+      @files ||= OpenAI::Files.new(client: self)
     end
 
     def finetunes
-      @finetunes ||= OpenAI::Finetunes.new
+      @finetunes ||= OpenAI::Finetunes.new(client: self)
     end
 
     def images
-      @images ||= OpenAI::Images.new
+      @images ||= OpenAI::Images.new(client: self)
     end
 
     def models
-      @models ||= OpenAI::Models.new
+      @models ||= OpenAI::Models.new(client: self)
     end
 
     def moderations(parameters: {})
-      OpenAI::Client.post(path: "/moderations", parameters: parameters)
+      post(path: "/moderations", parameters: parameters)
     end
 
-    def self.get(path:)
+    def get(path:)
       HTTParty.get(
         uri(path: path),
         headers: headers
       )
     end
 
-    def self.post(path:, parameters: nil)
+    def post(path:, parameters: nil)
       HTTParty.post(
         uri(path: path),
         headers: headers,
@@ -54,22 +63,24 @@ module OpenAI
       )
     end
 
-    def self.delete(path:)
+    def delete(path:)
       HTTParty.delete(
         uri(path: path),
         headers: headers
       )
     end
 
-    private_class_method def self.uri(path:)
-      URI_BASE + Ruby::OpenAI.configuration.api_version + path
+    private
+
+    def uri(path:)
+      URI_BASE + api_version + path
     end
 
-    private_class_method def self.headers
+    def headers
       {
         "Content-Type" => "application/json",
-        "Authorization" => "Bearer #{Ruby::OpenAI.configuration.access_token}",
-        "OpenAI-Organization" => Ruby::OpenAI.configuration.organization_id
+        "Authorization" => "Bearer #{access_token}",
+        "OpenAI-Organization" => organization_id
       }
     end
   end

--- a/lib/ruby/openai/files.rb
+++ b/lib/ruby/openai/files.rb
@@ -1,29 +1,34 @@
 module OpenAI
   class Files
-    def initialize(access_token: nil, organization_id: nil)
-      Ruby::OpenAI.configuration.access_token = access_token if access_token
-      Ruby::OpenAI.configuration.organization_id = organization_id if organization_id
+    def initialize(client: nil, access_token: nil,
+                   organization_id: OpenAI::Client::NULL_ORGANIZATION_ID)
+      @client = if client.nil?
+                  OpenAI::Client.new(access_token: access_token,
+                                     organization_id: organization_id)
+                else
+                  client
+                end
     end
 
     def list
-      OpenAI::Client.get(path: "/files")
+      @client.get(path: "/files")
     end
 
     def upload(parameters: {})
       validate(file: parameters[:file])
 
-      OpenAI::Client.post(
+      @client.post(
         path: "/files",
         parameters: parameters.merge(file: File.open(parameters[:file]))
       )
     end
 
     def retrieve(id:)
-      OpenAI::Client.get(path: "/files/#{id}")
+      @client.get(path: "/files/#{id}")
     end
 
     def delete(id:)
-      OpenAI::Client.delete(path: "/files/#{id}")
+      @client.delete(path: "/files/#{id}")
     end
 
     private

--- a/lib/ruby/openai/finetunes.rb
+++ b/lib/ruby/openai/finetunes.rb
@@ -1,28 +1,33 @@
 module OpenAI
   class Finetunes
-    def initialize(access_token: nil, organization_id: nil)
-      Ruby::OpenAI.configuration.access_token = access_token if access_token
-      Ruby::OpenAI.configuration.organization_id = organization_id if organization_id
+    def initialize(client: nil, access_token: nil,
+                   organization_id: OpenAI::Client::NULL_ORGANIZATION_ID)
+      @client = if client.nil?
+                  OpenAI::Client.new(access_token: access_token,
+                                     organization_id: organization_id)
+                else
+                  client
+                end
     end
 
     def list
-      OpenAI::Client.get(path: "/fine-tunes")
+      @client.get(path: "/fine-tunes")
     end
 
     def create(parameters: {})
-      OpenAI::Client.post(path: "/fine-tunes", parameters: parameters)
+      @client.post(path: "/fine-tunes", parameters: parameters)
     end
 
     def retrieve(id:)
-      OpenAI::Client.get(path: "/fine-tunes/#{id}")
+      @client.get(path: "/fine-tunes/#{id}")
     end
 
     def cancel(id:)
-      OpenAI::Client.post(path: "/fine-tunes/#{id}/cancel")
+      @client.post(path: "/fine-tunes/#{id}/cancel")
     end
 
     def events(id:)
-      OpenAI::Client.get(path: "/fine-tunes/#{id}/events")
+      @client.get(path: "/fine-tunes/#{id}/events")
     end
   end
 end

--- a/lib/ruby/openai/images.rb
+++ b/lib/ruby/openai/images.rb
@@ -1,20 +1,25 @@
 module OpenAI
   class Images
-    def initialize(access_token: nil, organization_id: nil)
-      Ruby::OpenAI.configuration.access_token = access_token if access_token
-      Ruby::OpenAI.configuration.organization_id = organization_id if organization_id
+    def initialize(client: nil, access_token: nil,
+                   organization_id: OpenAI::Client::NULL_ORGANIZATION_ID)
+      @client = if client.nil?
+                  OpenAI::Client.new(access_token: access_token,
+                                     organization_id: organization_id)
+                else
+                  client
+                end
     end
 
     def generate(parameters: {})
-      OpenAI::Client.post(path: "/images/generations", parameters: parameters)
+      @client.post(path: "/images/generations", parameters: parameters)
     end
 
     def edit(parameters: {})
-      OpenAI::Client.post(path: "/images/edits", parameters: open_files(parameters))
+      @client.post(path: "/images/edits", parameters: open_files(parameters))
     end
 
     def variations(parameters: {})
-      OpenAI::Client.post(path: "/images/variations", parameters: open_files(parameters))
+      @client.post(path: "/images/variations", parameters: open_files(parameters))
     end
 
     private

--- a/lib/ruby/openai/models.rb
+++ b/lib/ruby/openai/models.rb
@@ -1,16 +1,21 @@
 module OpenAI
   class Models
-    def initialize(access_token: nil, organization_id: nil)
-      Ruby::OpenAI.configuration.access_token = access_token if access_token
-      Ruby::OpenAI.configuration.organization_id = organization_id if organization_id
+    def initialize(client: nil, access_token: nil,
+                   organization_id: OpenAI::Client::NULL_ORGANIZATION_ID)
+      @client = if client.nil?
+                  OpenAI::Client.new(access_token: access_token,
+                                     organization_id: organization_id)
+                else
+                  client
+                end
     end
 
     def list
-      OpenAI::Client.get(path: "/models")
+      @client.get(path: "/models")
     end
 
     def retrieve(id:)
-      OpenAI::Client.get(path: "/models/#{id}")
+      @client.get(path: "/models/#{id}")
     end
   end
 end


### PR DESCRIPTION
Addresses #149 

This is a quick and dirty conversion to multi-tenancy for the gem.  That said, both Rubocop and specs pass and I expect it works in practice.

Some changes I'd suggest on top of this commit:

1. Make the Files, Finetunes, Images, and Models classes non-instantiable except via the Client object.  All access to these APIs should go through a Client object.  This would dramatically simplify the initializers for these classes
2. Potentially add a `default_client` class method to OpenAI::Client, which would produce a memoized OpenAI::Client object that is initialized with the global parameters
3. Consider swapping out Httparty for connection pools, to minimize latency under production conditions
4. Maybe exclude the organization header from the header set if the value is nil?  I don't think we need to send in that case.
5. Allow the global configuration to have a missing access key, and shift that error to the Client upon initialization.

I don't think these changes make the gem any more difficult to use.  The only change from a user perspective is that setting the API credentials on a single client doesn't change it for the whole app.  So if you don't set the global credentials, you will need to invoke every Client instance with credentials.

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
