### PR TITLE
Update the POST actions so that they use the correct Content-Type headers

### DIFF
--- a/lib/ruby/openai/client.rb
+++ b/lib/ruby/openai/client.rb
@@ -8,15 +8,15 @@ module OpenAI
     end
 
     def completions(parameters: {})
-      OpenAI::Client.post(path: "/completions", parameters: parameters)
+      OpenAI::Client.json_post(path: "/completions", parameters: parameters)
     end
 
     def edits(parameters: {})
-      OpenAI::Client.post(path: "/edits", parameters: parameters)
+      OpenAI::Client.json_post(path: "/edits", parameters: parameters)
     end
 
     def embeddings(parameters: {})
-      OpenAI::Client.post(path: "/embeddings", parameters: parameters)
+      OpenAI::Client.json_post(path: "/embeddings", parameters: parameters)
     end
 
     def files
@@ -36,7 +36,7 @@ module OpenAI
     end
 
     def moderations(parameters: {})
-      OpenAI::Client.post(path: "/moderations", parameters: parameters)
+      OpenAI::Client.json_post(path: "/moderations", parameters: parameters)
     end
 
     def self.get(path:)
@@ -46,11 +46,19 @@ module OpenAI
       )
     end
 
-    def self.post(path:, parameters: nil)
+    def self.json_post(path:, parameters:)
       HTTParty.post(
         uri(path: path),
         headers: headers,
-        body: parameters.to_json
+        body: parameters&.to_json
+      )
+    end
+
+    def self.multipart_post(path:, parameters: nil)
+      HTTParty.post(
+        uri(path: path),
+        headers: headers.merge({ "Content-Type" => "multipart/form-data" }),
+        body: parameters
       )
     end
 

--- a/lib/ruby/openai/files.rb
+++ b/lib/ruby/openai/files.rb
@@ -12,7 +12,7 @@ module OpenAI
     def upload(parameters: {})
       validate(file: parameters[:file])
 
-      OpenAI::Client.post(
+      OpenAI::Client.multipart_post(
         path: "/files",
         parameters: parameters.merge(file: File.open(parameters[:file]))
       )

--- a/lib/ruby/openai/finetunes.rb
+++ b/lib/ruby/openai/finetunes.rb
@@ -10,7 +10,7 @@ module OpenAI
     end
 
     def create(parameters: {})
-      OpenAI::Client.post(path: "/fine-tunes", parameters: parameters)
+      OpenAI::Client.json_post(path: "/fine-tunes", parameters: parameters)
     end
 
     def retrieve(id:)
@@ -18,7 +18,7 @@ module OpenAI
     end
 
     def cancel(id:)
-      OpenAI::Client.post(path: "/fine-tunes/#{id}/cancel")
+      OpenAI::Client.multipart_post(path: "/fine-tunes/#{id}/cancel")
     end
 
     def events(id:)

--- a/lib/ruby/openai/images.rb
+++ b/lib/ruby/openai/images.rb
@@ -6,15 +6,15 @@ module OpenAI
     end
 
     def generate(parameters: {})
-      OpenAI::Client.post(path: "/images/generations", parameters: parameters)
+      OpenAI::Client.json_post(path: "/images/generations", parameters: parameters)
     end
 
     def edit(parameters: {})
-      OpenAI::Client.post(path: "/images/edits", parameters: open_files(parameters))
+      OpenAI::Client.multipart_post(path: "/images/edits", parameters: open_files(parameters))
     end
 
     def variations(parameters: {})
-      OpenAI::Client.post(path: "/images/variations", parameters: open_files(parameters))
+      OpenAI::Client.multipart_post(path: "/images/variations", parameters: open_files(parameters))
     end
 
     private


### PR DESCRIPTION
This change also fixes the existing NPE on the cancel action.

I'm backporting these changes from my larger scale rewrite, because the latter is getting larger and diverting more substantially from the existing gem.

While this commit / PR doesn't contain any additional specs, I'd recommend that some unit tests be added (or pulled back from the rewrite branch) to ensure against regression.  The VCR-based specs are not sufficient as is.

This is an alternative to #142 , implementing the suggestion I made there.

It's worth noting that the only reason the existing specs are passing is because VCR is doing default matching - method and URI - and is not matching request headers or body.  So the content-type and the body are getting ignored.  I attempted to turn on matching there, but I got weird results (it looked like it was running new episodes) on my attempt so I let it go for the moment. 

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
