### PR TITLE
Adds body and headers matching for VCR

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,13 @@ require "dotenv/load"
 require "ruby/openai"
 require "vcr"
 
+Dir[File.expand_path("spec/support/**/*.rb")].sort.each { |f| require f }
+
 VCR.configure do |c|
   c.hook_into :webmock
   c.cassette_library_dir = "spec/fixtures/cassettes"
-  c.default_cassette_options = { record: ENV["NO_VCR"] == "true" ? :all : :new_episodes }
+  c.default_cassette_options = { record: ENV["NO_VCR"] == "true" ? :all : :new_episodes,
+                                 match_requests_on: [:method, :uri, VCRMultipartMatcher.new] }
   c.filter_sensitive_data("<OPENAI_ACCESS_TOKEN>") { Ruby::OpenAI.configuration.access_token }
   c.filter_sensitive_data("<OPENAI_ORGANIZATION_ID>") { Ruby::OpenAI.configuration.organization_id }
 end

--- a/spec/support/vcr_multipart_matcher.rb
+++ b/spec/support/vcr_multipart_matcher.rb
@@ -1,0 +1,47 @@
+class VCRMultipartMatcher
+  MULTIPART_HEADER_MATCHER = %r{^multipart/form-data; boundary=(.+)$}.freeze
+  BOUNDARY_SUBSTITUTION = "----MultipartBoundaryAbcD3fGhiXyz00001".freeze
+
+  def call(request1, request2)
+    return false unless same_content_type?(request1, request2)
+    unless headers_excluding_content_type(request1) == headers_excluding_content_type(request2)
+      return false
+    end
+
+    normalized_multipart_body(request1) == normalized_multipart_body(request2)
+  end
+
+  private
+
+  def same_content_type?(request1, request2)
+    content_type1 = (request1.headers["Content-Type"] || []).first.to_s
+    content_type2 = (request2.headers["Content-Type"] || []).first.to_s
+
+    if multipart_request?(content_type1)
+      multipart_request?(content_type2)
+    elsif multipart_request?(content_type2)
+      false
+    else
+      content_type1 == content_type2
+    end
+  end
+
+  def headers_excluding_content_type(request)
+    request.headers.except("Content-Type")
+  end
+
+  def normalized_multipart_body(request)
+    content_type = (request.headers["Content-Type"] || []).first.to_s
+
+    return request.headers unless multipart_request?(content_type)
+
+    boundary = MULTIPART_HEADER_MATCHER.match(content_type)[1]
+    request.body.gsub(boundary, BOUNDARY_SUBSTITUTION)
+  end
+
+  def multipart_request?(content_type)
+    return false if content_type.empty?
+
+    MULTIPART_HEADER_MATCHER.match?(content_type)
+  end
+end


### PR DESCRIPTION
This change ensures that VCR-based specs match not only the method and URI, but also the headers and body of the request.  Had this been in place earlier, all of the bugs resolved in 3.0.2 and 3.0.3 would have caused spec failures.

This includes code to handle the fact that the boundary used in multipart form posts changes randomly from request to request.

I opened a related issue on VCR - https://github.com/vcr/vcr/issues/960 .

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
