### PR TITLE
Upgrade bundler version used for bundling Gemfile to eliminate DidYouMean warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,4 +77,4 @@ DEPENDENCIES
   webmock (~> 3.18.1)
 
 BUNDLED WITH
-   2.2.20
+   2.4.3


### PR DESCRIPTION
When running `bundle ...` on the current Gemfile a warning:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
```

is generated.  This is a a result of an outdated `bundler`.  Updating the `bundler` in the `Gemfile.lock` resolves the issue.

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
