### PR TITLE
adds the ability to configure the timeout for the OpenAI requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,24 @@ Then you can create a client like this:
     client = OpenAI::Client.new
 ```
 
+#### Setting request timeout
+
+The default timeout for any OpenAI request is 60 seconds. You can change that passing the `request_timeout` when initializing the client:
+
+```ruby
+    client = OpenAI::Client.new(access_token: "access_token_goes_here", request_timeout: 25)
+```
+
+or when configuring the gem:
+
+```ruby
+    OpenAI.configure do |config|
+        config.access_token = ENV.fetch('OPENAI_ACCESS_TOKEN')
+        config.organization_id = ENV.fetch('OPENAI_ORGANIZATION_ID') # Optional.
+        config.request_timeout = 25 # Optional
+    end
+```
+
 ### Models
 
 There are different models that can be used to generate text. For a full list and to retrieve information about a single models:

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -13,14 +13,16 @@ module OpenAI
 
   class Configuration
     attr_writer :access_token
-    attr_accessor :api_version, :organization_id
+    attr_accessor :api_version, :organization_id, :request_timeout
 
     DEFAULT_API_VERSION = "v1".freeze
+    DEFAULT_REQUEST_TIMEOUT = 60
 
     def initialize
       @access_token = nil
       @api_version = DEFAULT_API_VERSION
       @organization_id = nil
+      @request_timeout = DEFAULT_REQUEST_TIMEOUT
     end
 
     def access_token

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -2,9 +2,10 @@ module OpenAI
   class Client
     URI_BASE = "https://api.openai.com/".freeze
 
-    def initialize(access_token: nil, organization_id: nil)
+    def initialize(access_token: nil, organization_id: nil, request_timeout: nil)
       OpenAI.configuration.access_token = access_token if access_token
       OpenAI.configuration.organization_id = organization_id if organization_id
+      OpenAI.configuration.request_timeout = request_timeout if request_timeout
     end
 
     def completions(parameters: {})
@@ -42,7 +43,8 @@ module OpenAI
     def self.get(path:)
       HTTParty.get(
         uri(path: path),
-        headers: headers
+        headers: headers,
+        timeout: request_timeout
       )
     end
 
@@ -50,7 +52,8 @@ module OpenAI
       HTTParty.post(
         uri(path: path),
         headers: headers,
-        body: parameters&.to_json
+        body: parameters&.to_json,
+        timeout: request_timeout
       )
     end
 
@@ -58,14 +61,16 @@ module OpenAI
       HTTParty.post(
         uri(path: path),
         headers: headers.merge({ "Content-Type" => "multipart/form-data" }),
-        body: parameters
+        body: parameters,
+        timeout: request_timeout
       )
     end
 
     def self.delete(path:)
       HTTParty.delete(
         uri(path: path),
-        headers: headers
+        headers: headers,
+        timeout: request_timeout
       )
     end
 
@@ -79,6 +84,10 @@ module OpenAI
         "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
         "OpenAI-Organization" => OpenAI.configuration.organization_id
       }
+    end
+
+    private_class_method def self.request_timeout
+      OpenAI.configuration.request_timeout
     end
   end
 end

--- a/spec/openai/client/client_spec.rb
+++ b/spec/openai/client/client_spec.rb
@@ -2,4 +2,32 @@ RSpec.describe OpenAI::Client do
   it "can be initialized" do
     expect { OpenAI::Client.new }.not_to raise_error
   end
+
+  describe ".get" do
+    it "passes timeout as param to httparty" do
+      expect(HTTParty).to receive(:get).with(any_args, hash_including(timeout: 60))
+      OpenAI::Client.get(path: "abc")
+    end
+  end
+
+  describe ".json_post" do
+    it "passes timeout as param to httparty" do
+      expect(HTTParty).to receive(:post).with(any_args, hash_including(timeout: 60))
+      OpenAI::Client.json_post(path: "abc", parameters: { foo: :bar })
+    end
+  end
+
+  describe ".multipart_post" do
+    it "passes timeout as param to httparty" do
+      expect(HTTParty).to receive(:post).with(any_args, hash_including(timeout: 60))
+      OpenAI::Client.multipart_post(path: "abc")
+    end
+  end
+
+  describe ".delete" do
+    it "passes timeout as param to httparty" do
+      expect(HTTParty).to receive(:delete).with(any_args, hash_including(timeout: 60))
+      OpenAI::Client.delete(path: "abc")
+    end
+  end
 end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe OpenAI do
     let(:access_token) { "abc123" }
     let(:api_version) { "v2" }
     let(:organization_id) { "def456" }
+    let(:request_timeout) { 25 }
 
     before do
       OpenAI.configure do |config|
@@ -20,6 +21,7 @@ RSpec.describe OpenAI do
       expect(OpenAI.configuration.access_token).to eq(access_token)
       expect(OpenAI.configuration.api_version).to eq(api_version)
       expect(OpenAI.configuration.organization_id).to eq(organization_id)
+      expect(OpenAI.configuration.request_timeout).to eq(60)
     end
 
     context "without an access token" do
@@ -27,6 +29,21 @@ RSpec.describe OpenAI do
 
       it "raises an error" do
         expect { OpenAI::Client.new.completions }.to raise_error(OpenAI::ConfigurationError)
+      end
+    end
+
+    context "with custom timeout" do
+      before do
+        OpenAI.configure do |config|
+          config.request_timeout = request_timeout
+        end
+      end
+
+      it "returns the config" do
+        expect(OpenAI.configuration.access_token).to eq(access_token)
+        expect(OpenAI.configuration.api_version).to eq(api_version)
+        expect(OpenAI.configuration.organization_id).to eq(organization_id)
+        expect(OpenAI.configuration.request_timeout).to eq(request_timeout)
       end
     end
   end


### PR DESCRIPTION
This PR adds the ability to set the timeout (in seconds) for OpenAI requests. It can be configured by two ways:
1) Passing `request_timeout` named param when initializing the client. eg.
```ruby
OpenAI::Client.new(request_timeout: 25)
```

2) when configuring the gem. eg.
```ruby
OpenAI.configure do |config|
  config.request_timeout = 25
end
```

The default value is 60 seconds, which is the default value of the `Net::HTTP` class

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
