### PR TITLE
Add parallel request queuing for Typhoeus request replacement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ruby-openai (3.3.1)
+      ruby-limiter (>= 2.2.2)
       typhoeus (>= 1.4.0)
 
 GEM
@@ -53,6 +54,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
+    ruby-limiter (2.2.2)
     ruby-progressbar (1.11.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-openai (3.3.0)
+    ruby-openai (3.3.1)
       typhoeus (>= 1.4.0)
 
 GEM

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -1,4 +1,5 @@
 require "typhoeus"
+require "ruby-limiter"
 
 require_relative "openai/client"
 require_relative "openai/files"

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -7,7 +7,7 @@ module OpenAI
       OpenAI.configuration.organization_id = organization_id if organization_id
 
       # OpenAI has a 3000 request/min hard rate limit if your account is over 48 hours old,
-      # We default to 500 below that because it seems as if their timing is 100% accurate,
+      # We default to 500 below that because it seems as if their timing is not 100% accurate,
       # but it's settable to anything
       @rate_queue = Limiter::RateQueue.new(rate_limit, interval: 60, balanced: true)
 
@@ -107,7 +107,7 @@ module OpenAI
       )
     end
 
-    def self.queue_json_post(path:, parameters:, rate_queue:, &block)
+    def self.queue_json_post(path:, rate_queue:, parameters:, &block)
       request = Typhoeus::Request.new(
         uri(path: path),
         method: :post,
@@ -131,7 +131,7 @@ module OpenAI
       )
     end
 
-    def self.queue_multipart_post(path:, parameters: nil, rate_queue:, &block)
+    def self.queue_multipart_post(path:, rate_queue:, parameters: nil, &block)
       request = Typhoeus.request(
         uri(path: path),
         method: :post,

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -1,6 +1,5 @@
 module OpenAI
   class Client
-    extend Limiter::Mixin
     URI_BASE = "https://api.openai.com/".freeze
 
     self.rate_queue = Limiter::RateQueue.new(100, interval: 1)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -7,7 +7,7 @@ module OpenAI
       OpenAI.configuration.organization_id = organization_id if organization_id
 
       # The default is 200 connections, so that's the default we're keeping here
-      @hydra = Typhoeus::Hydra.hydra.new(max_concurrency: max_concurrency)
+      @hydra = Typhoeus::Hydra.new(max_concurrency: max_concurrency)
     end
 
     def completions(parameters: {})

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -2,11 +2,12 @@ module OpenAI
   class Client
     URI_BASE = "https://api.openai.com/".freeze
 
-    def initialize(access_token: nil, organization_id: nil)
+    def initialize(access_token: nil, organization_id: nil, max_concurrency: 200)
       OpenAI.configuration.access_token = access_token if access_token
       OpenAI.configuration.organization_id = organization_id if organization_id
 
-      @hydra = Typhoeus::Hydra.hydra
+      # The default is 200 connections, so that's the default we're keeping here
+      @hydra = Typhoeus::Hydra.hydra.new(max_concurrency: max_concurrency)
     end
 
     def completions(parameters: {})

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -8,7 +8,7 @@ module OpenAI
 
       # OpenAI has a 3000 request/min hard rate limit if your account is over 48 hours old,
       # so we're defaulting to that, but allowing smaller if you want
-      @rate_queue = Limiter::RateQueue.new(rate_limit, interval: 60)
+      @rate_queue = Limiter::RateQueue.new(rate_limit, interval: 60, balanced: true)
 
       # The default is 200 connections, so that's the default we're keeping here
       @hydra = Typhoeus::Hydra.new(max_concurrency: max_concurrency)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -2,12 +2,13 @@ module OpenAI
   class Client
     URI_BASE = "https://api.openai.com/".freeze
 
-    def initialize(access_token: nil, organization_id: nil, max_concurrency: 200, rate_limit: 3000)
+    def initialize(access_token: nil, organization_id: nil, max_concurrency: 200, rate_limit: 2500)
       OpenAI.configuration.access_token = access_token if access_token
       OpenAI.configuration.organization_id = organization_id if organization_id
 
       # OpenAI has a 3000 request/min hard rate limit if your account is over 48 hours old,
-      # so we're defaulting to that, but allowing smaller if you want
+      # We default to 500 below that because it seems as if their timing is 100% accurate,
+      # but it's settable to anything
       @rate_queue = Limiter::RateQueue.new(rate_limit, interval: 60, balanced: true)
 
       # The default is 200 connections, so that's the default we're keeping here

--- a/lib/openai/version.rb
+++ b/lib/openai/version.rb
@@ -1,3 +1,3 @@
 module OpenAI
-  VERSION = "3.3.0".freeze
+  VERSION = "3.3.1".freeze
 end

--- a/lib/openai/version.rb
+++ b/lib/openai/version.rb
@@ -1,3 +1,3 @@
 module OpenAI
-  VERSION = "3.3.1".freeze
+  VERSION = "3.3.0".freeze
 end

--- a/ruby-openai.gemspec
+++ b/ruby-openai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "ruby-limiter", ">= 2.2.2"
   spec.add_dependency "typhoeus", ">= 1.4.0"
 
   spec.post_install_message = "Note if upgrading: The `::Ruby::OpenAI` module has been removed and all classes have been moved under the top level `::OpenAI` module. To upgrade, change `require 'ruby/openai'` to `require 'openai'` and change all references to `Ruby::OpenAI` to `OpenAI`."


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

This PR branches off the #194 PR to add optional batch and queuing of requests to better handle large data sets. This is especially useful for generating embeddings of large data sets. In testing it takes the total time to do 32k embeddings from ~5 hours to ~10 minutes.

## Usage
To use this new functionality there are two new optional parameters added to the initializer:
`client = OpenAI::Client.new(access_token: "xxxxx", rate_limit: 2500, max_concurrency: 10)`
### New Defaults:
 - `rate_limit`: 2500. The limit for OpenAI is 3000 requests/minute however the timing for it seems to be off a bit so we back off a bit to ensure success without slamming against the limit unpredictably.
 - `max_concurrency`: 200. This is the limit default for Typhoeus, but you can change this depending on what you need/can handle. In my testing this doesn't significantly change the the time it takes.

After initialization this PR adds a `queue_` version of all the functions that take a block to handle the response i.e.
```
client.queue_embeddings(parameters: { model: "text-embedding-ada-002", input: "It was a dark and stormy evening..." }) do |result|
    puts result.body
end
```

After queuing, a user calls `client.run_queued_requests` to begin the execution. Each finished block will run as the request finishes.

Errors and such should be managed in the response block.

## Notes:
- There's a few listing issues with this because of the length of the `Client` class and a few of the methods have more than ten lines. I'd recommend relaxing these rules if the team is OK with that, there's no way I could consider to refactor the lengths without adding a significant amount of complexity.
- There are no tests for this. As I discussed with @alexrudall I'm just not familiar with `VHS` and `RSpec` enough to do this properly (I'm a `minitest` guy for 17 years). I'm happy to add them if there's help to do so.
- Because there's no tests there's probably breaking changes that will need to be resolved before a final merge. I'm happy to do so once we get the testing up and running.
- This adds one dependency on `ruby-limiter` an up-to-date and maintained gem by Shopify (so it's legit) to manage the rate limiting, otherwise you pretty instantly slam up agains the OpenAI rate limiting and it's a lot of work to manage outside this gem.
- The commits are poorly documented, mostly because I wasn't considering upstreaming this at the time. However, the changes are pretty limited and self-explanatory for the most part.
