### PR TITLE
test: allow running tests without secrets

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,9 +26,14 @@ RSpec.configure do |c|
     rspec.syntax = :expect
   end
 
-  c.before(:all) do
-    OpenAI.configure do |config|
-      config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
+  OpenAI.configure do |config|
+    # to re-generate the recordings you need to have these in your ENV
+    config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN") do
+      if ENV["CI"] # rubocop:disable Style/GuardClause
+        "secret-needed-to-record-new-tests"
+      else
+        raise KeyError, "OPENAI_ACCESS_TOKEN must be in the ENV when not running in CI"
+      end
     end
   end
 end


### PR DESCRIPTION
Since we already have VCR recording tests, it should be
possible to run the test suite without requiring the credentials,
since they're only required for live tests.

If I'm just picking up the gem for a quick PR, this lowers the barrier to entry, I think.

 ## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?