### PR TITLE
Whisper example: files must be opened in binary mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The translations API takes as input the audio file in any of the supported langu
 response = client.translate(
     parameters: {
         model: "whisper-1",
-        file: File.open('path_to_file'),
+        file: File.open('path_to_file', 'rb'),
     })
 puts response.parsed_response['text']
 # => "Translation of the text"
@@ -293,7 +293,7 @@ The transcriptions API takes as input the audio file you want to transcribe and 
 response = client.transcribe(
     parameters: {
         model: "whisper-1",
-        file: File.open('path_to_file'),
+        file: File.open('path_to_file', 'rb'),
     })
 puts response.parsed_response['text']
 # => "Transcription of the text"


### PR DESCRIPTION
Fixed the whisper example in readme.md. Files must be opened in binary mode, otherwise it will not work.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
