### PR TITLE
Fix uri_base sample value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The default timeout for any OpenAI request is 120 seconds. You can change that p
 ```ruby
     client = OpenAI::Client.new(
         access_token: "access_token_goes_here",
-        uri_base: "https://oai.hconeai.com",
+        uri_base: "https://oai.hconeai.com/",
         request_timeout: 240
     )
 ```
@@ -87,7 +87,7 @@ or when configuring the gem:
     OpenAI.configure do |config|
         config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
         config.organization_id = ENV.fetch("OPENAI_ORGANIZATION_ID") # Optional
-        config.uri_base = "https://oai.hconeai.com" # Optional
+        config.uri_base = "https://oai.hconeai.com/" # Optional
         config.request_timeout = 240 # Optional
     end
 ```


### PR DESCRIPTION
The current sample value in README actually doesn't work, and results in url like `oai.hconeai.comv1`. The trailing slash is essential.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
