### PR TITLE
If token found, make specs always hit the actual API

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,12 +332,16 @@ After checking out the repo, run `bin/setup` to install dependencies. You can ru
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
+### Warning
+
+If you have an `OPENAI_ACCESS_TOKEN` in your `ENV`, running the specs will use this to run the specs against the actual API, which will be slow and cost you money - 2 cents or more! Remove it from your environment with `unset` or similar if you just want to run the specs against the stored VCR responses.
+
 ## Release
 
-First run the specs without VCR so they actually hit the API. This will cost about 2 cents. You'll need to add your `OPENAI_ACCESS_TOKEN=` in `.env`.
+First run the specs without VCR so they actually hit the API. This will cost 2 cents or more. Set OPENAI_ACCESS_TOKEN in your environment or pass it in like this:
 
 ```
-NO_VCR=true bundle exec rspec
+OPENAI_ACCESS_TOKEN=123abc bundle exec rspec
 ```
 
 Then update the version number in `version.rb`, update `CHANGELOG.md`, run `bundle install` to update Gemfile.lock, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |c|
     warning = "WARNING! Specs are hitting the OpenAI API using your OPENAI_ACCESS_TOKEN! This
 costs at least 2 cents per run and is very slow! If you don't want this, unset
 OPENAI_ACCESS_TOKEN to just run against the stored VCR responses.".freeze
-    warning = RSpec::Core::Formatters::ConsoleCodes.wrap(warning, :red)
+    warning = RSpec::Core::Formatters::ConsoleCodes.wrap(warning, :bold_red)
 
     c.before(:suite) { RSpec.configuration.reporter.message(warning) }
     c.after(:suite) { RSpec.configuration.reporter.message(warning) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ Dir[File.expand_path("spec/support/**/*.rb")].sort.each { |f| require f }
 VCR.configure do |c|
   c.hook_into :webmock
   c.cassette_library_dir = "spec/fixtures/cassettes"
-  c.default_cassette_options = { record: ENV["NO_VCR"] == "true" ? :all : :new_episodes,
+  c.default_cassette_options = { record: ENV["OPENAI_ACCESS_TOKEN"] ? :all : :new_episodes,
                                  match_requests_on: [:method, :uri, VCRMultipartMatcher.new] }
   c.filter_sensitive_data("<OPENAI_ACCESS_TOKEN>") { OpenAI.configuration.access_token }
   c.filter_sensitive_data("<OPENAI_ORGANIZATION_ID>") { OpenAI.configuration.organization_id }
@@ -28,7 +28,7 @@ RSpec.configure do |c|
 
   c.before(:all) do
     OpenAI.configure do |config|
-      config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
+      config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN", "dummy-token")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,21 +29,13 @@ RSpec.configure do |c|
   end
 
   if ENV.fetch("OPENAI_ACCESS_TOKEN", nil)
-    warning = "WARNING!
-    Specs are hitting the OpenAI API using your OPENAI_ACCESS_TOKEN!
-    This costs at least 2 cents per run and is very slow!
-    If you don't want this, unset OPENAI_ACCESS_TOKEN to just run against the stored VCR responses.
-    ".freeze
-    colour_code = 31 # red
-    colour_warning = "\e[#{colour_code}m\n#{warning}\e[0m".freeze
+    warning = "WARNING! Specs are hitting the OpenAI API using your OPENAI_ACCESS_TOKEN! This
+costs at least 2 cents per run and is very slow! If you don't want this, unset
+OPENAI_ACCESS_TOKEN to just run against the stored VCR responses.".freeze
+    warning = RSpec::Core::Formatters::ConsoleCodes.wrap(warning, :red)
 
-    c.before(:suite) do
-      warn(colour_warning)
-    end
-
-    c.after(:suite) do
-      warn(colour_warning)
-    end
+    c.before(:suite) { RSpec.configuration.reporter.message(warning) }
+    c.after(:suite) { RSpec.configuration.reporter.message(warning) }
   end
 
   c.before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,10 @@ Dir[File.expand_path("spec/support/**/*.rb")].sort.each { |f| require f }
 VCR.configure do |c|
   c.hook_into :webmock
   c.cassette_library_dir = "spec/fixtures/cassettes"
-  c.default_cassette_options = { record: ENV.fetch("OPENAI_ACCESS_TOKEN", nil) ? :all : :new_episodes,
-                                 match_requests_on: [:method, :uri, VCRMultipartMatcher.new] }
+  c.default_cassette_options = {
+    record: ENV.fetch("OPENAI_ACCESS_TOKEN", nil) ? :all : :new_episodes,
+    match_requests_on: [:method, :uri, VCRMultipartMatcher.new]
+  }
   c.filter_sensitive_data("<OPENAI_ACCESS_TOKEN>") { OpenAI.configuration.access_token }
   c.filter_sensitive_data("<OPENAI_ORGANIZATION_ID>") { OpenAI.configuration.organization_id }
 end


### PR DESCRIPTION
- Makes specs always hit the API if a token is found, either in ENV or passed in explicitly
- Allow specs to run even if the user does not have `OPENAI_ACCESS_TOKEN` in ENV, as suggested in [https://github.com/alexrudall/ruby-openai/pull/214](https://github.com/alexrudall/ruby-openai/pull/214)

<img width="759" alt="Screenshot 2023-03-31 at 18 17 38" src="https://user-images.githubusercontent.com/7175262/229093704-1c11ef26-0686-42cd-9580-6c778abc2d6c.png">
