### PR TITLE
Update beta.openai.com link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ require "openai"
 
 ## Usage
 
-- Get your API key from [https://beta.openai.com/account/api-keys](https://beta.openai.com/account/api-keys)
-- If you belong to multiple organizations, you can get your Organization ID from [https://beta.openai.com/account/org-settings](https://beta.openai.com/account/org-settings)
+- Get your API key from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys)
+- If you belong to multiple organizations, you can get your Organization ID from [https://platform.openai.com/account/org-settings](https://platform.openai.com/account/org-settings)
 
 ### Quickstart
 


### PR DESCRIPTION
The links aren't broken (they do redirect to `platform.openai.com`), but they're outdated.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
