### PR TITLE
stream option should take any callable not just a proc

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -8,9 +8,11 @@ module OpenAI
 
     def json_post(path:, parameters:)
       to_json(conn.post(uri(path: path)) do |req|
-        if parameters[:stream].is_a?(Proc)
+        if parameters[:stream].respond_to?(:call)
           req.options.on_data = to_json_stream(user_proc: parameters[:stream])
           parameters[:stream] = true # Necessary to tell OpenAI to stream.
+        elsif parameters[:stream]
+          raise ArgumentError, "stream must be callable"
         end
 
         req.headers = headers


### PR DESCRIPTION
Due to the way that Ruby closures work for procs, it's quite limiting to limit the stream interface to just Proc objects. This PR makes a tiny change so that callable objects work too. (Anything that implements a `call` method.)

Here's a simple example from my project MagmaChat:

```
  class StreamProcessor
    def initialize(bot:, buffer:, message:)
      Rails.logger.info "💦💦💦 initializing stream processor for message: #{message} 💦💦💦"
      @buffer = buffer
      @message = message
    end

    def call(chunk, _bytesize=nil)
      Rails.logger.info "💦💦💦 streaming chunk: #{chunk} (#{_bytesize} bytes) 💦💦💦"
      if new_content = chunk.dig("choices", 0, "delta", "content")
        @buffer << new_content
        ActiveRecord::Base.logger.silence do
          @message.update(content: @message.content + new_content)
        end
      end
    end
  end
```