### PR TITLE
Handle streaming errors and return to user proc, with `result_type`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,13 @@ client.chat(
         messages: [{ role: "user", content: "Describe a character called Anna!"}], # Required.
         temperature: 0.7,
         stream: proc do |chunk, _bytesize|
-            print chunk.dig("choices", 0, "delta", "content")
+            if chunk["result_type"] == "data"
+                print chunk.dig("choices", 0, "delta", "content")
+            elsif chunk["result_type"] == "error"
+                STDERR.puts "Error: #{chunk.inspect}"
+            else
+                STDERR.puts "Unknown chunk type: #{chunk.inspect}"
+            end
         end
     })
 # => "Anna is a young woman in her mid-twenties, with wavy chestnut hair that falls to her shoulders..."


### PR DESCRIPTION
Currently when streaming, errors are ignored and never returned to the user's code.  This includes non-starter errors (eg wrong API key) as well as errors encountered in the course of usage (eg context length exceeded).  These are discussed  in https://github.com/alexrudall/ruby-openai/issues/256 and https://github.com/alexrudall/ruby-openai/pull/270 .

This PR (the one you are reading) offers an alternative solution: 

- Errors are returned to the user's code as well as data blocks
- Every returned structure has a "result_type" injected into the top level of the JSON, one of:
  - "data"
  - "error"
  - "unknown"

Specs have been updated, but in short:

`data: { "some": "json" }` chunks are returned as `data`  result_type
`error: { "some": "json" }` chunks are returned as `error` result_type
`{"error": {"some": "json"} }` chunks are returned as `error` result_type
`{"some": "json"}` chunks are returned as `unknown` result_type

Note that this is carefully crafted to ensure backward compatibility with existing code!  For example, this sample code will work unchanged:

```rb
stream: proc do |chunk, _bytesize|
  print chunk.dig("choices", 0, "delta", "content")
end
```

.... it will just ignore the `result_type` field and look for chunks matching the expected shape.

Feedback or change requests welcome.

Thanks BTW for an awesome gem, we're super happy with it!

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
