### PR TITLE
Skip flatten.each in HTTP to_json_stream

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -54,7 +54,7 @@ module OpenAI
     # @return [Proc] An outer proc that iterates over a raw stream, converting it to JSON.
     def to_json_stream(user_proc:)
       proc do |chunk, _|
-        chunk.scan(/(?:data|error): (\{.*\})/i).flatten.each do |data|
+        chunk.scan(/(?:data|error): (\{.*\})/i) do |data,|
           user_proc.call(JSON.parse(data))
         rescue JSON::ParserError
           # Ignore invalid JSON.

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -54,7 +54,7 @@ module OpenAI
     # @return [Proc] An outer proc that iterates over a raw stream, converting it to JSON.
     def to_json_stream(user_proc:)
       proc do |chunk, _|
-        chunk.scan(/(?:data|error): (\{.*\})/i) do |data,|
+        chunk.scan(/(?<=data: |error: )\{.*\}/i) do |data|
           user_proc.call(JSON.parse(data))
         rescue JSON::ParserError
           # Ignore invalid JSON.


### PR DESCRIPTION
Process each scanned element from chunk without intermediate array created by scan, flattened and iterated again.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
