### PR TITLE
Add support for custom headers in configuration

### DIFF
--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -15,7 +15,8 @@ module OpenAI
 
   class Configuration
     attr_writer :access_token
-    attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout, :custom_headers
+    attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout,
+                  :custom_headers
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_URI_BASE = "https://api.openai.com/".freeze

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -15,7 +15,7 @@ module OpenAI
 
   class Configuration
     attr_writer :access_token
-    attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout
+    attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout, :custom_headers
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_URI_BASE = "https://api.openai.com/".freeze
@@ -28,6 +28,7 @@ module OpenAI
       @organization_id = nil
       @uri_base = DEFAULT_URI_BASE
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
+      @custom_headers = {}
     end
 
     def access_token

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -2,11 +2,12 @@ module OpenAI
   class Client
     extend OpenAI::HTTP
 
-    def initialize(access_token: nil, organization_id: nil, uri_base: nil, request_timeout: nil)
+    def initialize(access_token: nil, organization_id: nil, uri_base: nil, request_timeout: nil, custom_headers: nil)
       OpenAI.configuration.access_token = access_token if access_token
       OpenAI.configuration.organization_id = organization_id if organization_id
       OpenAI.configuration.uri_base = uri_base if uri_base
       OpenAI.configuration.request_timeout = request_timeout if request_timeout
+      OpenAI.configuration.custom_headers = custom_headers if custom_headers
     end
 
     def chat(parameters: {})

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -2,7 +2,8 @@ module OpenAI
   class Client
     extend OpenAI::HTTP
 
-    def initialize(access_token: nil, organization_id: nil, uri_base: nil, request_timeout: nil, custom_headers: nil)
+    def initialize(access_token: nil, organization_id: nil, uri_base: nil, request_timeout: nil,
+                   custom_headers: nil)
       OpenAI.configuration.access_token = access_token if access_token
       OpenAI.configuration.organization_id = organization_id if organization_id
       OpenAI.configuration.uri_base = uri_base if uri_base

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -79,13 +79,13 @@ module OpenAI
     end
 
     def headers
-      return azure_headers if OpenAI.configuration.api_type == :azure
+      return azure_headers.merge(OpenAI.configuration.custom_headers) if OpenAI.configuration.api_type == :azure
 
       {
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
         "OpenAI-Organization" => OpenAI.configuration.organization_id
-      }
+      }.merge(OpenAI.configuration.custom_headers)
     end
 
     def azure_headers

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -79,7 +79,9 @@ module OpenAI
     end
 
     def headers
-      return azure_headers.merge(OpenAI.configuration.custom_headers) if OpenAI.configuration.api_type == :azure
+      if OpenAI.configuration.api_type == :azure
+        return azure_headers.merge(OpenAI.configuration.custom_headers)
+      end
 
       {
         "Content-Type" => "application/json",

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -257,5 +257,25 @@ RSpec.describe OpenAI::HTTP do
                                 "api-key" => OpenAI.configuration.access_token })
       }
     end
+
+    describe "with custom headers" do
+      before do
+        OpenAI.configuration.custom_headers = {
+          "Helicone-Auth" => "Bearer foobar123"
+        }
+      end
+
+      after do
+        OpenAI.configuration.custom_headers = {}
+      end
+
+      let(:headers) { OpenAI::Client.send(:headers) }
+
+      it {
+        expect(headers).to eq({ "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
+                                "Content-Type" => "application/json", "OpenAI-Organization" => nil,
+                                "Helicone-Auth" => "Bearer foobar123" })
+      }
+    end
   end
 end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe OpenAI do
     let(:organization_id) { "def456" }
     let(:custom_uri_base) { "ghi789" }
     let(:custom_request_timeout) { 25 }
+    let(:custom_headers) { { "My-Custom-Header" => "Some Value" } }
 
     before do
       OpenAI.configure do |config|
@@ -24,6 +25,7 @@ RSpec.describe OpenAI do
       expect(OpenAI.configuration.organization_id).to eq(organization_id)
       expect(OpenAI.configuration.uri_base).to eq("https://api.openai.com/")
       expect(OpenAI.configuration.request_timeout).to eq(120)
+      expect(OpenAI.configuration.custom_headers).to eq({})
     end
 
     context "without an access token" do
@@ -34,11 +36,12 @@ RSpec.describe OpenAI do
       end
     end
 
-    context "with custom timeout and uri base" do
+    context "with custom timeout, uri base, and custom headers" do
       before do
         OpenAI.configure do |config|
           config.uri_base = custom_uri_base
           config.request_timeout = custom_request_timeout
+          config.custom_headers = custom_headers
         end
       end
 
@@ -48,6 +51,7 @@ RSpec.describe OpenAI do
         expect(OpenAI.configuration.organization_id).to eq(organization_id)
         expect(OpenAI.configuration.uri_base).to eq(custom_uri_base)
         expect(OpenAI.configuration.request_timeout).to eq(custom_request_timeout)
+        expect(OpenAI.configuration.custom_headers).to eq(custom_headers)
       end
     end
   end


### PR DESCRIPTION
Allows user to set custom headers that will be sent with all requests.

This is particularly useful when configuring something like Helicone, where setting a custom `uri_base` isn't enough. Helicone requires `{ "Helicone-Auth": "Bearer HELICONE_API_KEY" }` at a minimum, plus supports additional headers for additional configuration.

I wasn't sure whether to call this `custom_headers` or `additional_headers`. The existing headers aren't removed, but can be overwritten when using the same name. (with one minor exception when doing a `multipart_post` which sets the `Content-Type` header)

Fixes #279

