### PR TITLE
Update model name to ext-embedding-ada-002 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ You can use the embeddings endpoint to get a vector of numbers representing an i
 ```ruby
 response = client.embeddings(
     parameters: {
-        model: "babbage-similarity",
+        model: "ext-embedding-ada-002",
         input: "The food was delicious and the waiter..."
     }
 )


### PR DESCRIPTION
This is a very small change, but while trying out the sampling code in the README, I noticed that the name of the embedded model is not recommended.

> We recommend using text-embedding-ada-002 for nearly all use cases. It’s better, cheaper, and simpler to use. Read the [blog post announcement](https://openai.com/blog/new-and-improved-embedding-model).

https://platform.openai.com/docs/guides/embeddings/what-are-embeddings

The official site also recommends using text-embedding-ada-002.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
