### PR TITLE
Support multiple deployment_ids for azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,19 @@ To use the [Azure OpenAI Service](https://learn.microsoft.com/en-us/azure/cognit
     end
 ```
 
-where `AZURE_OPENAI_URI` is e.g. `https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo`
+where `AZURE_OPENAI_URI` is e.g. `https://custom-domain.openai.azure.com`
+
+Then add the `deployment_id` to the api calls. e.g:
+
+``` ruby
+client.embeddings(
+  deployment_id: 'gpt-35-turbo',
+  parameters: {
+    model: 'text-embedding-ada-002',
+    input:
+  }
+)
+```
 
 ### Models
 

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -6,7 +6,9 @@ module OpenAI
       end&.body)
     end
 
-    def json_post(path:, parameters:)
+    def json_post(path:, parameters:, deployment_id: nil)
+      path = "/openai/deployments/#{deployment_id}/#{path}" if deployment_id
+
       to_json(conn.post(uri(path: path)) do |req|
         if parameters[:stream].respond_to?(:call)
           req.options.on_data = to_json_stream(user_proc: parameters[:stream])


### PR DESCRIPTION
This enables support for calling multiple azure deployments when using the library. This follows the same convention as the official python openai package.

So `client.embeddings(deployment_id: 'my-gpt-deployment', ...rest_of_args)`

Since a embedding model would be one deployment and the actual chat model would be another this is required to use both.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
