### PR TITLE
Add token_count client method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,9 @@ gem "dotenv", "~> 2.8.1"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.12"
 gem "rubocop", "~> 1.50.2"
-gem "tiktoken_ruby", require: false
 gem "vcr", "~> 6.1.0"
 gem "webmock", "~> 3.18.1"
+
+if RUBY_VERSION >= "2.7"
+  gem "tiktoken_ruby", require: false
+end

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,6 @@ gem "dotenv", "~> 2.8.1"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.12"
 gem "rubocop", "~> 1.50.2"
+gem "tiktoken_ruby", require: false
 gem "vcr", "~> 6.1.0"
 gem "webmock", "~> 3.18.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
     public_suffix (5.0.1)
     rainbow (3.1.1)
     rake (13.0.6)
+    rb_sys (0.9.81)
     regexp_parser (2.8.0)
     rexml (3.2.5)
     rspec (3.12.0)
@@ -60,6 +61,8 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    tiktoken_ruby (0.0.5)
+      rb_sys (~> 0.9.68)
     unicode-display_width (2.4.2)
     vcr (6.1.0)
     webmock (3.18.1)
@@ -77,6 +80,7 @@ DEPENDENCIES
   rspec (~> 3.12)
   rubocop (~> 1.50.2)
   ruby-openai!
+  tiktoken_ruby
   vcr (~> 6.1.0)
   webmock (~> 3.18.1)
 

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -54,5 +54,32 @@ module OpenAI
     def translate(parameters: {})
       OpenAI::Client.multipart_post(path: "/audio/translations", parameters: parameters)
     end
+
+    def token_count(parameters: {})
+      contents = parameters[:messages]&.map { |message| message[:content] }&.join(" ") || nil
+      return 0 if contents.nil?
+
+      if self.class.tiktoken_defined?
+        model = parameters[:model] || self.class.default_tiktoken_model
+        encoding = Tiktoken.encoding_for_model(model) || Tiktoken.encoding_for_model(self.class.default_tiktoken_model)
+        encoding.encode(contents).size
+      else
+        # https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them
+        count_by_chars = contents.size / 4.0
+        count_by_words = contents.split.size * 4.0 / 3
+        estimate = ((count_by_chars + count_by_words)/2.0).round
+        [1, estimate].max
+      end
+    end
+
+    protected
+
+    def self.tiktoken_defined?
+      !!(defined? ::Tiktoken)
+    end
+
+    def self.default_tiktoken_model
+      "gpt-3.5-turbo".freeze
+    end
   end
 end

--- a/spec/openai/client/token_count_spec.rb
+++ b/spec/openai/client/token_count_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe OpenAI::Client do
+  describe "#token_count" do
+    let(:messages) { [
+      { content: "Red is my favorite color." },
+      { content: "You miss 100% of the shots you don't take." },
+      { content: "Ingredients for banana bread can include 1 egg or 3 eggs." },
+      { content: "Egg is not a necessary ingredient." }
+    ]}
+    let(:client) { OpenAI::Client.new }
+    let(:model) { nil }
+    let(:token_count) do
+      parameters = { messages: messages }
+      parameters[:model] = model if model
+      client.token_count(parameters: parameters)
+    end
+
+    context "without tiktoken" do
+      context "without model" do
+        it "counts tokens naively" do
+          expect(client.class).to receive(:tiktoken_defined?).and_return(false)
+          expect(token_count).to eq(41)
+        end
+      end
+
+      context "with model" do
+        let(:model) { "model_name_does_not_matter" }
+        it "counts tokens naively" do
+          expect(client.class).to receive(:tiktoken_defined?).and_return(false)
+          expect(token_count).to eq(41)
+        end
+      end
+    end
+
+    context "with tiktoken" do
+      require 'tiktoken_ruby'
+
+      it "recognizes tiktoken" do
+        expect(client.class.tiktoken_defined?).to eq(true)
+      end
+
+      context "with davinci" do
+        let(:model) { "davinci" }
+        it "counts tokens" do
+          expect(token_count).to eq(37)
+        end
+      end
+
+      context "with gpt-3.5" do
+        let(:model) { "gpt-3.5-turbo" }
+        it "counts tokens" do
+          expect(token_count).to eq(40)
+        end
+      end
+    end
+  end
+end

--- a/spec/openai/client/token_count_spec.rb
+++ b/spec/openai/client/token_count_spec.rb
@@ -31,8 +31,12 @@ RSpec.describe OpenAI::Client do
       end
     end
 
-    context "with tiktoken" do
-      require 'tiktoken_ruby'
+    context "with tiktoken", if: RUBY_VERSION >= "2.7" do
+      begin
+        require 'tiktoken_ruby'
+      rescue LoadError => e
+        raise e if RUBY_VERSION >= "2.7"
+      end
 
       it "recognizes tiktoken" do
         expect(client.class.tiktoken_defined?).to eq(true)


### PR DESCRIPTION
## token_count

As discussed in #291 , it can be useful in many cases to support calculating the token-count of messages before sending them to OpenAI.

This PR adds an `OpenAI::Client.token_count` instance method which does this. To minimize astonishment, it accepts the same `parameters` input as the other methods. Its output is always a nonnegative integer.

If the caller has already `require`'d the `tiktoken_ruby` module, this new method automatically uses it to calculate exactly the number of tokens that OpenAI will parse. (Because `parameters` includes the model name, we know we're using the same algorithm OpenAI will use.)

Or, if `Tiktoken` is not available, it uses the two "helpful rules of thumb" in OpenAI's [docs](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them) and averages them as an estimate.

Because testing the `Tiktoken` code paths works best if the module is actually included and not mocked, this PR adds that gem to the `Gemfile`. Note that this does not change the dependency list. Also, because the test is written against two specific, existing models, that module's counts should not change in the future and thus the test results should be pretty future-proof.

I'm happy to make any changes desired. Just let me know.

## ruby 2.6

`Tiktoken` requires ruby >= 2.7.  This gem requires ruby >= 2.6. I wanted to keep this gem's test suite passing on all versions of ruby.

What I did was the slightly unorthodox method of editing `Gemfile` to only make mention of `tiktoken` when running on ruby >= 2.7, and add conditionals in the test file to skip those three tests on ruby 2.6.

It works — I checked it locally on ruby 2.6, 2.7, and 3.1.

But... it's a little ugly. Personally, if you asked me, since 2.6 isn't getting security updates, I wouldn't want to encourage its use. I would revert the ugly changes (f8d548103a6f11b8231192894f2951fa3e6de5ef) and set the [required version](https://github.com/alexrudall/ruby-openai/blob/ef982fe99ed3585c2238a33ab891294113fe894a/ruby-openai.gemspec#L12) to 2.7. But I didn't want to make that change without discussing/consulting about it first. What's in this PR works fine and changes things as minimally as possible.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
