### PR TITLE
Add OpenAI.rough_token_count class method

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ To use the [Azure OpenAI Service](https://learn.microsoft.com/en-us/azure/cognit
 
 where `AZURE_OPENAI_URI` is e.g. `https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo`
 
+### Counting Tokens
+
+OpenAI parses prompt text into [tokens](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them), which are words or portions of words. (These tokens are unrelated to your API access_token.) Counting tokens can help you estimate your [costs](https://openai.com/pricing). It can also help you ensure your prompt text size is within the max-token limits of your model's context window, and choose an appropriate [`max_tokens`](https://platform.openai.com/docs/api-reference/chat/create#chat/create-max_tokens) completion parameter so your response will fit as well.
+
+To estimate the token-count of your text:
+
+```ruby
+OpenAI.rough_token_count("Your text")
+```
+
+If you need a more accurate count, try [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby).
+
 ### Models
 
 There are different models that can be used to generate text. For a full list and to retrieve information about a single model:
@@ -184,7 +196,7 @@ client.chat(
 # => "Anna is a young woman in her mid-twenties, with wavy chestnut hair that falls to her shoulders..."
 ```
 
-Note: the API docs state that token usage is included in the streamed chat chunk objects, but this doesn't currently appear to be the case. If you need to work out how many tokens are being used while streaming, try [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby).
+Note: the API docs state that token usage is included in the streamed chat chunk objects, but this doesn't currently appear to be the case. To count tokens while streaming, try `OpenAI.rough_token_count` or [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby).
 
 ### Functions
 

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -53,6 +53,8 @@ module OpenAI
     yield(configuration)
   end
 
+  # Estimate the number of tokens in a string, using the rules of thumb from OpenAI:
+  # https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them
   def self.rough_token_count(content = "")
     raise ArgumentError, "rough_token_count requires a string" unless content.is_a? String
     return 0 if content.empty?

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -52,4 +52,14 @@ module OpenAI
   def self.configure
     yield(configuration)
   end
+
+  def self.rough_token_count(content = "")
+    raise ArgumentError, "rough_token_count requires a string" unless content.is_a? String
+    return 0 if content.empty?
+
+    count_by_chars = content.size / 4.0
+    count_by_words = content.split.size * 4.0 / 3
+    estimate = ((count_by_chars + count_by_words) / 2.0).round
+    [1, estimate].max
+  end
 end

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -55,4 +55,25 @@ RSpec.describe OpenAI do
       end
     end
   end
+
+  describe "#rough_token_count" do
+    context "on a non-String" do
+      it "raises an error" do
+        expect { OpenAI.rough_token_count([]) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "on the empty string" do
+      it "returns 0" do
+        expect(OpenAI.rough_token_count("")).to eq(0)
+      end
+    end
+
+    context "on a string" do
+      let(:content) { "Red is my favorite color. Egg is not a necessary ingredient." }
+      it "estimates tokens" do
+        expect(OpenAI.rough_token_count(content)).to eq(15)
+      end
+    end
+  end
 end


### PR DESCRIPTION
It can be useful to estimate the token count of some text before sending it to OpenAI. This PR adds an `OpenAI.rough_token_count` class method which does this.

To perform the estimation, it uses the two "helpful rules of thumb" in OpenAI's [docs](https://help.openai.com/en/articles/4936856-what-are-tokens-and-how-to-count-them) and takes the arithmetic average.

The empty string returns 0, and any other string returns an integer greater than 0.

This is a rewrite of #306 to remove the Tiktoken functionality and change the interface as requested.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
