### PR TITLE
:memo: fix an small error in the README.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Upload your fine-tuning data in a `.jsonl` file as above and get its ID:
 
 ```ruby
 response = client.files.upload(parameters: { file: "path/to/sentiment.jsonl", purpose: "fine-tune" })
-file_id = JSON.parse(response.body)["id"]
+file_id = response["id"]
 ```
 
 You can then use this file ID to create a fine-tune model:


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

## Description

- Calling `client.files.upload` already returns the response as a Hash so we should not call `.body` on the response.