### PR TITLE
Adding `raw` as optional parameter to expose faraday object

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -17,7 +17,8 @@ module OpenAI
         end
 
         req.headers = headers
-        req.body = parameters.except(:raw).to_json
+        new_params = parameters.reject { |key, _| key == :raw }
+        req.body = new_params.to_json
       end
 
       return nil unless response

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -73,6 +73,25 @@ RSpec.describe OpenAI::Client do
             end
           end
         end
+
+        describe "raw responses" do
+          let(:response) do
+            OpenAI::Client.new.chat(
+              parameters: {
+                model: model,
+                messages: messages,
+                stream: stream,
+                raw: true
+              }
+            )
+          end
+          
+          it "succeeds and provides access to status", :focus do
+            VCR.use_cassette(cassette) do
+              expect(response[:status]).to eq(200)
+            end
+          end
+        end
       end
 
       context "with model: gpt-3.5-turbo-0301" do

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe OpenAI::Client do
               }
             )
           end
-          
+
           it "succeeds and provides access to status", :focus do
             VCR.use_cassette(cassette) do
               expect(response[:status]).to eq(200)


### PR DESCRIPTION
Faraday object exposes status, body and headers

Explanation
- Currently json_post only gives you the body as json and not access to the response object.
- `raw` parameter is not passed to LLM provider
- `raw` parameter determines whether to return Faraday object and convert only the body to json

Resolves https://github.com/alexrudall/ruby-openai/issues/255

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
