### PR TITLE
Adds ability to capture HTTP errors

### DIFF
--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -1,6 +1,7 @@
 require "faraday"
 require "faraday/multipart"
 
+require_relative "openai/error"
 require_relative "openai/http"
 require_relative "openai/client"
 require_relative "openai/files"
@@ -11,7 +12,6 @@ require_relative "openai/audio"
 require_relative "openai/version"
 
 module OpenAI
-  class Error < StandardError; end
   class ConfigurationError < Error; end
 
   class Configuration

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -17,7 +17,7 @@ module OpenAI
   class Configuration
     attr_writer :access_token
     attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout,
-                  :extra_headers
+                  :extra_headers, :raise_error
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_URI_BASE = "https://api.openai.com/".freeze
@@ -31,6 +31,7 @@ module OpenAI
       @uri_base = DEFAULT_URI_BASE
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @extra_headers = nil
+      @raise_error = false
     end
 
     def access_token

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -10,6 +10,7 @@ module OpenAI
       uri_base
       request_timeout
       extra_headers
+      raise_error
     ].freeze
     attr_reader *CONFIG_KEYS
 

--- a/lib/openai/error.rb
+++ b/lib/openai/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module OpenAI
+  class Error < StandardError
+  end
+end

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -1,7 +1,7 @@
+require_relative "http/error"
+
 module OpenAI
   module HTTP
-    class Error < ::Faraday::Error; end
-
     def get(path:)
       to_json(conn.get(uri(path: path)) do |req|
         req.headers = headers

--- a/lib/openai/http/error.rb
+++ b/lib/openai/http/error.rb
@@ -1,0 +1,89 @@
+module OpenAI
+  module HTTP
+    # Heavily borrowed from Faraday::Error
+    # https://github.com/lostisland/faraday/blob/ea30bd0b543882f1cf26e75ac4e46e0705fa7e68/lib/faraday/error.rb
+    class Error < ::OpenAI::Error
+      attr_reader :response, :wrapped_exception
+
+      def initialize(exc = nil, response = nil)
+        @wrapped_exception = nil unless defined?(@wrapped_exception)
+        @response = nil unless defined?(@response)
+        super(exc_msg_and_response!(exc, response))
+      end
+
+      def backtrace
+        if @wrapped_exception
+          @wrapped_exception.backtrace
+        else
+          super
+        end
+      end
+
+      def inspect
+        inner = +''
+        inner << " wrapped=#{@wrapped_exception.inspect}" if @wrapped_exception
+        inner << " response=#{@response.inspect}" if @response
+        inner << " #{super}" if inner.empty?
+        %(#<#{self.class}#{inner}>)
+      end
+
+      def response_status
+        return unless @response
+
+        @response.respond_to?(:status) ? @response.status : @response[:status]
+      end
+
+      def response_headers
+        return unless @response
+
+        @response.response_to?(:headers) ? @response.headers : @response[:headers]
+      end
+
+      def response_body
+        return unless @response
+
+        @response.respond_to?(:body) ? @response.body : @response[:body]
+      end
+
+      protected
+
+      # Pulls out potential parent exception and response hash, storing them in
+      # instance variables.
+      # exc      - Either an Exception, a string message, or a response hash.
+      # response - Hash
+      #              :status  - Optional integer HTTP response status
+      #              :headers - String key/value hash of HTTP response header
+      #                         values.
+      #              :body    - Optional string HTTP response body.
+      #              :request - Hash
+      #                           :method   - Symbol with the request HTTP method.
+      #                           :url      - URI object with the url requested.
+      #                           :url_path - String with the url path requested.
+      #                           :params   - String key/value hash of query params
+      #                                     present in the request.
+      #                           :headers  - String key/value hash of HTTP request
+      #                                     header values.
+      #                           :body     - String HTTP request body.
+      #
+      # If a subclass has to call this, then it should pass a string message
+      # to `super`. See NilStatusError.
+      def exc_msg_and_response!(exc, response = nil)
+        if @response.nil? && @wrapped_exception.nil?
+          @wrapped_exception, msg, @response = exc_msg_and_response(exc, response)
+          return msg
+        end
+
+        exc.to_s
+      end
+
+      # Pulls out potential parent exception and response hash.
+      def exc_msg_and_response(exc, response = nil)
+        return [exc, exc.message, response] if exc.respond_to?(:backtrace)
+
+        return [nil, "the server responded with status #{exc[:status]}", exc] if exc.respond_to?(:each_key)
+
+        [nil, exc.to_s, response]
+      end
+    end
+  end
+end

--- a/spec/openai/client/client_spec.rb
+++ b/spec/openai/client/client_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe OpenAI::Client do
         organization_id: "organization_id1",
         request_timeout: 60,
         uri_base: "https://oai.hconeai.com/",
-        extra_headers: { "test" => "X-Test" }
+        extra_headers: { "test" => "X-Test" },
+        raise_error: true
       )
     end
     let!(:c2) do
@@ -32,7 +33,8 @@ RSpec.describe OpenAI::Client do
         access_token: "access_token2",
         organization_id: nil,
         request_timeout: 1,
-        uri_base: "https://example.com/"
+        uri_base: "https://example.com/",
+        raise_error: false
       )
     end
 
@@ -42,6 +44,7 @@ RSpec.describe OpenAI::Client do
       expect(c0.organization_id).to eq("organization_id0")
       expect(c0.request_timeout).to eq(OpenAI::Configuration::DEFAULT_REQUEST_TIMEOUT)
       expect(c0.uri_base).to eq(OpenAI::Configuration::DEFAULT_URI_BASE)
+      expect(c0.raise_error).to eq(false)
       expect(c0.send(:headers).values).to include("Bearer #{c0.access_token}")
       expect(c0.send(:headers).values).to include(c0.organization_id)
       expect(c0.send(:conn).options.timeout).to eq(OpenAI::Configuration::DEFAULT_REQUEST_TIMEOUT)
@@ -54,6 +57,7 @@ RSpec.describe OpenAI::Client do
       expect(c1.organization_id).to eq("organization_id1")
       expect(c1.request_timeout).to eq(60)
       expect(c1.uri_base).to eq("https://oai.hconeai.com/")
+      expect(c1.raise_error).to eq(true)
       expect(c1.send(:headers).values).to include(c1.access_token)
       expect(c1.send(:conn).options.timeout).to eq(60)
       expect(c1.send(:uri, path: "")).to include("https://oai.hconeai.com/")
@@ -65,6 +69,7 @@ RSpec.describe OpenAI::Client do
       expect(c2.organization_id).to eq("organization_id0") # Fall back to default.
       expect(c2.request_timeout).to eq(1)
       expect(c2.uri_base).to eq("https://example.com/")
+      expect(c2.raise_error).to eq(false)
       expect(c2.send(:headers).values).to include("Bearer #{c2.access_token}")
       expect(c2.send(:headers).values).to include(c2.organization_id)
       expect(c2.send(:conn).options.timeout).to eq(1)

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -27,6 +27,18 @@ RSpec.describe OpenAI::HTTP do
           expect(timeout_errors).to include(error.class)
         end
       end
+
+      context "when raise_error is configured to true" do
+        let(:timeout_errors) { [described_class::Error] }
+        before { OpenAI.configuration.raise_error = true }
+        after { OpenAI.configuration.raise_error = false }
+
+        it "times out with OpenAI::HTTP::Error" do
+          expect { response }.to raise_error do |error|
+            expect(timeout_errors).to include(error.class)
+          end
+        end
+      end
     end
 
     describe ".json_post" do
@@ -48,6 +60,18 @@ RSpec.describe OpenAI::HTTP do
             expect(timeout_errors).to include(error.class)
           end
         end
+
+        context "when raise_error is configured to true" do
+          let(:timeout_errors) { [described_class::Error] }
+          before { OpenAI.configuration.raise_error = true }
+          after { OpenAI.configuration.raise_error = false }
+
+          it "times out with OpenAI::HTTP::Error" do
+            expect { response }.to raise_error do |error|
+              expect(timeout_errors).to include(error.class)
+            end
+          end
+        end
       end
 
       context "streaming" do
@@ -61,6 +85,18 @@ RSpec.describe OpenAI::HTTP do
         it "times out" do
           expect { response }.to raise_error do |error|
             expect(timeout_errors).to include(error.class)
+          end
+        end
+
+        context "when raise_error is configured to true" do
+          let(:timeout_errors) { [described_class::Error] }
+          before { OpenAI.configuration.raise_error = true }
+          after { OpenAI.configuration.raise_error = false }
+
+          it "times out with OpenAI::HTTP::Error" do
+            expect { response }.to raise_error do |error|
+              expect(timeout_errors).to include(error.class)
+            end
           end
         end
       end
@@ -81,6 +117,18 @@ RSpec.describe OpenAI::HTTP do
           expect(timeout_errors).to include(error.class)
         end
       end
+
+      context "when raise_error is configured to true" do
+        let(:timeout_errors) { [described_class::Error] }
+        before { OpenAI.configuration.raise_error = true }
+        after { OpenAI.configuration.raise_error = false }
+
+        it "times out with OpenAI::HTTP::Error" do
+          expect { response }.to raise_error do |error|
+            expect(timeout_errors).to include(error.class)
+          end
+        end
+      end
     end
 
     describe ".delete" do
@@ -91,6 +139,18 @@ RSpec.describe OpenAI::HTTP do
       it "times out" do
         expect { response }.to raise_error do |error|
           expect(timeout_errors).to include(error.class)
+        end
+      end
+
+      context "when raise_error is configured to true" do
+        let(:timeout_errors) { [described_class::Error] }
+        before { OpenAI.configuration.raise_error = true }
+        after { OpenAI.configuration.raise_error = false }
+
+        it "times out with OpenAI::HTTP::Error" do
+          expect { response }.to raise_error do |error|
+            expect(timeout_errors).to include(error.class)
+          end
         end
       end
     end


### PR DESCRIPTION
As of v4.0.0 of this gem, we lost the ability to access response headers and response status code.  Access to these is critical in safely handling HTTP failures that can happen when reaching out to OpenAI's API.

This introduces a new configuration option `raise_error` that allows users to raise a new `OpenAI::HTTP::Error` anytime the response status code is 4xx or 5xx, and provides access to the response's `status`, `headers`, and `body` on the error instance that is raised.

In #327, an approach to resolve this allows forcing a "raw" response to be returned.  For the specific case of handling HTTP errors though, this is not a straightforward solution that I would expect as a first-time user of the library.

Since Faraday is used, they have an excellent [`RaiseError`](https://github.com/lostisland/faraday/blob/v1.0.0/lib/faraday/response/raise_error.rb#L7) middleware ([recommended in their docs](https://lostisland.github.io/faraday/#/middleware/included/raising-errors?id=raising-errors)) that will raise a [Faraday::Error](https://github.com/lostisland/faraday/blob/v1.0.0/lib/faraday/error.rb) for any 4xx or 5xx response status codes.  Instances of this error contain a [`response` Hash attribute](https://github.com/lostisland/faraday/blob/v1.0.0/lib/faraday/response/raise_error.rb#L41) that include the `status`, `headers`, and `body` of the response.  This takes advantage of that error class and wraps it in a library-specific one so that end-users can rescue from this in a convenient way.

Some dis-advantages to this solution is that it is coupled with Faraday.  However, extending the new `OpenAI::HTTP::Error` class to conform to the same return object for the `response` accessor (a `Hash` with `status`, `headers`, and `body` keys) should be fairly straightforward if it is decided to move away from Farday in the future.  I have tried my best to avoid any Farday-specific mentions in the README for that reason.

Fixes #255

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
