### PR TITLE
Better SSE parsing

### DIFF
--- a/lib/openai/sse.rb
+++ b/lib/openai/sse.rb
@@ -1,0 +1,45 @@
+module OpenAI
+  module SSE
+    def to_completion_json_stream(completion_json_proc:)
+      @buffer = ""
+
+      proc do |chunk, _|
+        chunk = @buffer + chunk
+        @buffer = ""
+
+        blocks = chunk.split("\n\n", -1)
+
+        @buffer = process_blocks(blocks, completion_json_proc)
+      end
+    end
+
+    private
+
+    def process_blocks(blocks, completion_json_proc)
+      buffer = ""
+
+      while blocks.length.positive?
+        block = blocks.shift
+
+        if blocks.empty?
+          buffer = block unless block.empty?
+          break
+        end
+
+        process_block(block, completion_json_proc)
+      end
+
+      buffer
+    end
+
+    def process_block(block, completion_json_proc)
+      matches = /([^:]+):\s*(.+)/.match(block)
+      return unless matches
+
+      field_name, field_value = matches.captures
+      return unless %w[data error].include?(field_name)
+
+      completion_json_proc.call(field_value)
+    end
+  end
+end

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -108,7 +108,11 @@ RSpec.describe OpenAI::HTTP do
       context "when called with a string containing a single JSON object" do
         it "calls the user proc with the data parsed as JSON" do
           expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
-          stream.call('data: { "foo": "bar" }')
+          stream.call(<<~CHUNK)
+            data: { "foo": "bar" }
+
+            #
+          CHUNK
         end
       end
 
@@ -117,13 +121,14 @@ RSpec.describe OpenAI::HTTP do
           expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
           expect(user_proc).to receive(:call).with(JSON.parse('{"baz": "qud"}'))
 
-          stream.call(<<-CHUNK)
+          stream.call(<<~CHUNK)
             data: { "foo": "bar" }
 
             data: { "baz": "qud" }
 
             data: [DONE]
 
+            #
           CHUNK
         end
       end
@@ -134,36 +139,28 @@ RSpec.describe OpenAI::HTTP do
         it "does not call the user proc" do
           bad_examples.each do |chunk|
             expect(user_proc).to_not receive(:call)
-            stream.call(chunk)
+            stream.call("#{chunk}\n\n")
           end
         end
       end
 
       context "when called with a string containing that looks like a JSON object but is invalid" do
-        let(:chunk) do
-          <<-CHUNK
-            data: { "foo": "bar" }
-            data: { BAD ]:-> JSON }
-          CHUNK
-        end
-
         it "does not raise an error" do
           expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
 
           expect do
-            stream.call(chunk)
+            stream.call(<<~CHUNK)
+              data: { "foo": "bar" }
+
+              data: { BAD ]:-> JSON }
+
+              #
+            CHUNK
           end.not_to raise_error
         end
       end
 
       context "when called with a string containing an error" do
-        let(:chunk) do
-          <<-CHUNK
-            data: { "foo": "bar" }
-            error: { "message": "A bad thing has happened!" }
-          CHUNK
-        end
-
         it "does not raise an error" do
           expect(user_proc).to receive(:call).with(JSON.parse('{ "foo": "bar" }'))
           expect(user_proc).to receive(:call).with(
@@ -171,7 +168,23 @@ RSpec.describe OpenAI::HTTP do
           )
 
           expect do
-            stream.call(chunk)
+            stream.call(<<~CHUNK)
+              data: { "foo": "bar" }
+
+              error: { "message": "A bad thing has happened!" }
+
+              #
+            CHUNK
+          end.not_to raise_error
+        end
+      end
+
+      context "when called with JSON split across chunks" do
+        it "calls the user proc with the data parsed as JSON" do
+          expect(user_proc).to receive(:call).with(JSON.parse('{ "foo": "bar" }'))
+          expect do
+            stream.call("data: { \"foo\":")
+            stream.call(" \"bar\" }\n\n")
           end.not_to raise_error
         end
       end


### PR DESCRIPTION
The issue mentioned in #251 persists.

OpenAI reliably returns one completion JSON per SSE message. However, when intermediaries are placed between OpenAI and the client (e.g. a proxy), the combining and splitting of chunks during streaming/buffering (or even TCP fragmentation) can cause the client to receive chunks with completion fragments (invalid JSON).

This PR brings more [spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation)-compliant SSE parsing. Instead of stripping and ignoring whitespace, processes a chunk by splitting it into blocks delimited by `"\n\n"`, and buffering any remaining block that is not a full `data` field.

**More** spec-compliant, but not really fully spec-compliant: There's still no handling of multi-line data spread across adjacent `data` fields. But there's no need to make this a generic SSE parser since the only concern is hitting OpenAI.

I've updated the http tests by making them emit proper SSE chunks into the stream. I added a test for the fragmented completion JSON case.

Note that this is still a bit of a quick hack and not the best way to parse SSE. An ideal parser would process the stream line by line with a state machine (instead of YOLO splitting at `\n\n`).

I also noticed two issues that I did not address in the scope of this PR:

1. I don't think there's such thing as an `error` field in SSE. It's neither in the spec, nor in OpenAI's documentation. It would be nice to remove the handling of that, or mention in a code comment where it's coming from.
2. The code simply ignores JSON parse errors. IMHO, the library instead should be unforgiving and error out when an unexpected payload is received. The ignoring of parse errors is a convenience for not directly handling the `"[DONE]"` value omitted by OpenAI, and also the very JSON fragmentation issue that is not very common, but still a possibility in certain settings.