### PR TITLE
Proper SSE parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ruby-openai (5.1.0)
+      event_stream_parser (~> 0.3.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
 
@@ -16,6 +17,7 @@ GEM
       rexml
     diff-lcs (1.5.0)
     dotenv (2.8.1)
+    event_stream_parser (0.3.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -1,3 +1,5 @@
+require "event_stream_parser"
+
 module OpenAI
   module HTTP
     def get(path:)
@@ -53,13 +55,23 @@ module OpenAI
     # @param user_proc [Proc] The inner proc to call for each JSON object in the chunk.
     # @return [Proc] An outer proc that iterates over a raw stream, converting it to JSON.
     def to_json_stream(user_proc:)
-      proc do |chunk, _|
-        chunk.scan(/(?:data|error): (\{.*\})/i).flatten.each do |data|
-          user_proc.call(JSON.parse(data))
-        rescue JSON::ParserError
-          # Ignore invalid JSON.
+      parser = EventStreamParser::Parser.new
+
+      proc do |chunk, _bytes, env|
+        if env && env.status != 200
+          emit_json(json: chunk, user_proc: user_proc)
+        else
+          parser.feed(chunk) do |_type, data|
+            emit_json(json: data, user_proc: user_proc) unless data == "[DONE]"
+          end
         end
       end
+    end
+
+    def emit_json(json:, user_proc:)
+      user_proc.call(JSON.parse(json))
+    rescue JSON::ParserError
+      # Ignore invalid JSON.
     end
 
     def conn(multipart: false)

--- a/ruby-openai.gemspec
+++ b/ruby-openai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "event_stream_parser", "~> 0.3.0"
   spec.add_dependency "faraday", ">= 1"
   spec.add_dependency "faraday-multipart", ">= 1"
 end

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -108,42 +108,39 @@ RSpec.describe OpenAI::HTTP do
       context "when called with a string containing a single JSON object" do
         it "calls the user proc with the data parsed as JSON" do
           expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
-          stream.call('data: { "foo": "bar" }')
+          stream.call(<<~CHUNK)
+            data: { "foo": "bar" }
+
+            #
+          CHUNK
         end
       end
 
-      context "when called with string containing more than one JSON object" do
+      context "when called with a string containing more than one JSON object" do
         it "calls the user proc for each data parsed as JSON" do
           expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
           expect(user_proc).to receive(:call).with(JSON.parse('{"baz": "qud"}'))
 
-          stream.call(<<-CHUNK)
+          stream.call(<<~CHUNK)
             data: { "foo": "bar" }
 
             data: { "baz": "qud" }
 
             data: [DONE]
 
+            #
           CHUNK
         end
       end
 
-      context "when called with a string that does not even resemble a JSON object" do
-        let(:bad_examples) { ["", "foo", "data: ", "data: foo"] }
-
-        it "does not call the user proc" do
-          bad_examples.each do |chunk|
-            expect(user_proc).to_not receive(:call)
-            stream.call(chunk)
-          end
-        end
-      end
-
-      context "when called with a string containing that looks like a JSON object but is invalid" do
+      context "when called with string containing invalid JSON" do
         let(:chunk) do
-          <<-CHUNK
+          <<~CHUNK
             data: { "foo": "bar" }
-            data: { BAD ]:-> JSON }
+
+            data: NOT JSON
+
+            #
           CHUNK
         end
 
@@ -156,22 +153,31 @@ RSpec.describe OpenAI::HTTP do
         end
       end
 
-      context "when called with a string containing an error" do
-        let(:chunk) do
-          <<-CHUNK
-            data: { "foo": "bar" }
-            error: { "message": "A bad thing has happened!" }
-          CHUNK
-        end
+      context "when OpenAI returns an HTTP error" do
+        let(:chunk) { "{\"error\":{\"message\":\"A bad thing has happened!\"}}" }
+        let(:env) { Faraday::Env.new(status: 500) }
 
-        it "does not raise an error" do
-          expect(user_proc).to receive(:call).with(JSON.parse('{ "foo": "bar" }'))
+        it "does not raise an error and calls the user proc with the error parsed as JSON" do
           expect(user_proc).to receive(:call).with(
-            JSON.parse('{ "message": "A bad thing has happened!" }')
+            {
+              "error" => {
+                "message" => "A bad thing has happened!"
+              }
+            }
           )
 
           expect do
-            stream.call(chunk)
+            stream.call(chunk, 0, env)
+          end.not_to raise_error
+        end
+      end
+
+      context "when called with JSON split across chunks" do
+        it "calls the user proc with the data parsed as JSON" do
+          expect(user_proc).to receive(:call).with(JSON.parse('{ "foo": "bar" }'))
+          expect do
+            stream.call("data: { \"foo\":")
+            stream.call(" \"bar\" }\n\n")
           end.not_to raise_error
         end
       end

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -153,6 +153,26 @@ RSpec.describe OpenAI::HTTP do
         end
       end
 
+      context "wehn called with string containing Obie's invalid JSON" do
+        let(:chunk) do
+          <<~CHUNK
+            data: { "foo": "bar" }
+
+            data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":123,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":null,"fu
+
+            #
+          CHUNK
+        end
+
+        it "does not raise an error" do
+          expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
+
+          expect do
+            stream.call(chunk)
+          end.not_to raise_error
+        end
+      end
+
       context "when OpenAI returns an HTTP error" do
         let(:chunk) { "{\"error\":{\"message\":\"A bad thing has happened!\"}}" }
         let(:env) { Faraday::Env.new(status: 500) }


### PR DESCRIPTION
Follow up to #332

1. Switch to using `event_stream_parser`, a spec-compliant event stream parser (that I recently published)
2. ~~The stream proc now receives an optional second argument for any errors encountered during parsing -- consumers should know, instead of these errors being silently ignored by this library~~
3. Explicitly check for `"[DONE]"` chunks.
4. ~~Remove bits about errors OpenAI does not send~~
5. ~~Tweak bit about token usage in streams (it's not a public feature yet)~~
6. Check HTTP response code and only try to parse the body as an error JSON if it's not OK.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
