### PR TITLE
Robust parsing and raising exceptions on HTTP errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     ruby-openai (5.1.0)
+      event_stream_parser (~> 0.3.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
 
@@ -16,6 +17,7 @@ GEM
       rexml
     diff-lcs (1.5.0)
     dotenv (2.8.1)
+    event_stream_parser (0.3.0)
     faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ puts response.dig("choices", 0, "message", "content")
 
 [Quick guide to streaming ChatGPT with Rails 7 and Hotwire](https://gist.github.com/alexrudall/cb5ee1e109353ef358adb4e66631799d)
 
-You can stream from the API in realtime, which can be much faster and used to create a more engaging user experience. Pass a [Proc](https://ruby-doc.org/core-2.6/Proc.html) (or any object with a `#call` method) to the `stream` parameter to receive the stream of text chunks as they are generated. Each time one or more chunks is received, the proc will be called once with each chunk, parsed as a Hash. If OpenAI returns an error, `ruby-openai` will pass that to your proc as a Hash.
+You can stream from the API in realtime, which can be much faster and used to create a more engaging user experience. Pass a [Proc](https://ruby-doc.org/core-2.6/Proc.html) (or any object with a `#call` method) to the `stream` parameter to receive the stream of completion chunks as they are generated. Each time one or more chunks is received, the proc will be called once with each chunk, parsed as a Hash.
 
 ```ruby
 client.chat(
@@ -188,14 +188,14 @@ client.chat(
         model: "gpt-3.5-turbo", # Required.
         messages: [{ role: "user", content: "Describe a character called Anna!"}], # Required.
         temperature: 0.7,
-        stream: proc do |chunk, _bytesize|
-            print chunk.dig("choices", 0, "delta", "content")
+        stream: proc do |chunk, error|
+            print chunk.dig("choices", 0, "delta", "content") unless error
         end
     })
 # => "Anna is a young woman in her mid-twenties, with wavy chestnut hair that falls to her shoulders..."
 ```
 
-Note: the API docs state that token usage is included in the streamed chat chunk objects, but this doesn't currently appear to be the case. To count tokens while streaming, try `OpenAI.rough_token_count` or [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby).
+Note: OpenAPI currently does not report token usage for streaming responses. To count tokens while streaming, try `OpenAI.rough_token_count` or [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby).
 
 ### Functions
 

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -67,6 +67,7 @@ module OpenAI
       Faraday.new do |f|
         f.options[:timeout] = @request_timeout
         f.request(:multipart) if multipart
+        f.response :raise_error
       end
     end
 

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -58,8 +58,6 @@ module OpenAI
       parser = EventStreamParser::Parser.new
       parser.stream do |_type, data|
         user_proc.call(JSON.parse(data)) unless data == "[DONE]"
-      rescue StandardError => e
-        user_proc.call(nil, e)
       end
     end
 

--- a/ruby-openai.gemspec
+++ b/ruby-openai.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "event_stream_parser", "~> 0.3.0"
   spec.add_dependency "faraday", ">= 1"
   spec.add_dependency "faraday-multipart", ">= 1"
 end

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat_with_error_response.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat_with_error_response.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.openai.com/v1/chat/completions
+      body:
+        encoding: UTF-8
+        string: '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+      headers:
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <OPENAI_ACCESS_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 400
+        message: Bad Request
+      headers:
+        Date:
+          - Mon, 14 Aug 2023 15:02:13 GMT
+        Content-Type:
+          - application/json
+      body:
+        encoding: UTF-8
+        string: |+
+          {
+              "error": {
+                  "message": "Test error",
+                  "type": "test_error",
+                  "param": null,
+                  "code": "test"
+              }
+          }
+    recorded_at: Mon, 14 Aug 2023 15:02:13 GMT
+
+recorded_with: VCR 6.1.0

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -72,6 +72,30 @@ RSpec.describe OpenAI::Client do
               end
             end
           end
+
+          context "with an error response" do
+            let(:cassette) { "#{model} streamed chat with error response".downcase }
+
+            it "raises an HTTP error" do
+              VCR.use_cassette(cassette) do
+                begin
+                  response
+                rescue Faraday::BadRequestError => error
+                  expect(error.response).to include(status: 400)
+                  expect(error.response[:body]).to eq({
+                    "error" => {
+                      "message" => "Test error",
+                      "type" => "test_error",
+                      "param" => nil,
+                      "code" => "test",
+                    }
+                  })
+                else
+                  fail "Expected to raise Faraday::BadRequestError"
+                end
+              end
+            end
+        end
         end
       end
 

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -78,24 +78,22 @@ RSpec.describe OpenAI::Client do
 
             it "raises an HTTP error" do
               VCR.use_cassette(cassette) do
-                begin
-                  response
-                rescue Faraday::BadRequestError => error
-                  expect(error.response).to include(status: 400)
-                  expect(error.response[:body]).to eq({
-                    "error" => {
-                      "message" => "Test error",
-                      "type" => "test_error",
-                      "param" => nil,
-                      "code" => "test",
-                    }
-                  })
-                else
-                  fail "Expected to raise Faraday::BadRequestError"
-                end
+                response
+              rescue Faraday::BadRequestError => e
+                expect(e.response).to include(status: 400)
+                expect(e.response[:body]).to eq({
+                                                  "error" => {
+                                                    "message" => "Test error",
+                                                    "type" => "test_error",
+                                                    "param" => nil,
+                                                    "code" => "test"
+                                                  }
+                                                })
+              else
+                raise "Expected to raise Faraday::BadRequestError"
               end
             end
-        end
+          end
         end
       end
 

--- a/spec/openai/client/finetunes_spec.rb
+++ b/spec/openai/client/finetunes_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe OpenAI::Client do
 
       # It takes too long to fine-tune a model so we can delete it when running the test suite
       # against the live API. Instead, we just check that the API returns an error.
-      it "returns an error" do
+      it "raises an error" do
         VCR.use_cassette(cassette) do
-          expect(response.dig("error", "message")).to include("does not exist")
+          expect { response }.to raise_error(Faraday::ResourceNotFound)
         end
       end
 

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -134,9 +134,10 @@ RSpec.describe OpenAI::HTTP do
       end
 
       context "when called with a string that is not valid JSON" do
-        it "populates the error argument" do
-          expect(user_proc).to receive(:call).with(nil, an_instance_of(JSON::ParserError))
-          stream.call("data: foo\n\n")
+        it "raises a JSON::ParserError" do
+          expect { stream.call("data: foo\n\n") }.to raise_error do |error|
+            expect(error).to be_a(JSON::ParserError)
+          end
         end
       end
 


### PR DESCRIPTION
#338, in an effort to fix event stream parsing, lost the ability to grab the error JSON returned in the body.

I'm working on this draft to extend that implementation and make a breaking change in ruby-openai to actually raise exceptions on errors. 

## All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
