### PR TITLE
Fix Maintain Unchanged Hash Parameter in Method json_post

### DIFF
--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -31,13 +31,15 @@ RSpec.describe OpenAI::HTTP do
 
     describe ".json_post" do
       let(:response) do
-        OpenAI::Client.new.chat(
-          parameters: {
-            model: "gpt-3.5-turbo",
-            messages: [{ role: "user", content: "Hello!" }],
-            stream: stream
-          }
-        )
+        OpenAI::Client.new.chat(parameters: parameters)
+      end
+
+      let(:parameters) do
+        {
+          model: "gpt-3.5-turbo",
+          messages: [{ role: "user", content: "Hello!" }],
+          stream: stream
+        }
       end
 
       context "not streaming" do
@@ -62,6 +64,12 @@ RSpec.describe OpenAI::HTTP do
           expect { response }.to raise_error do |error|
             expect(timeout_errors).to include(error.class)
           end
+        end
+
+        it "doesn't change the parameters stream proc" do
+          expect { response }.to raise_error(Faraday::ConnectionFailed)
+
+          expect(parameters[:stream]).to eq(stream)
         end
       end
     end


### PR DESCRIPTION
## Description:

When calling the `chat` method, the parameters used when calling it are being altered, specifically the parameters[:stream] entry:

```ruby
parameters = {
     model: "gpt-3.5-turbo", # Required.
     messages: [{ role: "user", content: "Describe a character called Anna!"}], # Required.
     temperature: 0.7,
     stream: proc do |chunk, _bytesize|
         print chunk.dig("choices", 0, "delta", "content")
     end
}
client.chat(parameters: parameters)

puts parameters[:stream]
# true
```

This can cause bugs as parameters should remain unchanged, we noticed it when we tried retrying the request on some OpenAi network failures, we called the method again with the same parameters and noticed streaming wouldn't work then.

**Impact**: This change does not affect the external behavior of the chat method but ensures parameter integrity across multiple calls.

This PR was made in collaboration with @vickymadrid03 and @nicastelo 👏 

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
