### PR TITLE
Merge extra headers into request headers for more flexibility

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -17,7 +17,7 @@ module OpenAI
           raise ArgumentError, "The stream parameter must be a Proc or have a #call method"
         end
 
-        req.headers = headers
+        req.headers = headers(extra_headers: parameters[:extra_headers])
         req.body = parameters.to_json
       end&.body)
     end
@@ -95,7 +95,7 @@ module OpenAI
         azure_headers
       else
         openai_headers
-      end.merge(@extra_headers || {})
+      end.merge(@extra_headers || {}).merge(extra_headers || {})
     end
 
     def openai_headers

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -286,4 +286,27 @@ RSpec.describe OpenAI::HTTP do
       }
     end
   end
+
+  describe 'extra_headers' do
+    describe '#chat' do
+      let(:client) { OpenAI::Client.new }
+      let(:extra_headers) { { 'Helicone-Property-Conversation': 'conversation-123' } }
+      let(:chat_params) do
+        {
+          parameters: {
+            model: 'gpt-3.5-turbo',
+            messages: [],
+            temperature: 0.1,
+            extra_headers: extra_headers
+          }
+        }
+      end
+
+      it 'includes extra headers in the chat request' do
+        expect(client).to receive(:chat).with(chat_params)
+
+        client.chat(chat_params)
+      end
+    end
+  end
 end


### PR DESCRIPTION
The http.rb file now merges extra headers into the request headers, allowing for more flexibility in the headers that can be sent with each request. This change is particularly useful when there are headers specific to a certain request that are not included in the default headers. 

`  OpenAI::Client.new.chat(
      parameters: {
        model: 'gpt-3.5-turbo',
        messages: Message.for_openai(trip.messages),
        temperature: 0.1,
        stream: stream_proc(message:),
        extra_headers: {
          'Helicone-Property-Conversation': 'conversation-123'
        }
      }
    )
  end`

The http_spec.rb file now includes a test to ensure that these extra headers are correctly included in the chat request.

Related [issue](https://github.com/alexrudall/ruby-openai/issues/333)


## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
