### PR TITLE
enable frozen string literals for performance and thread safety

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,4 +28,4 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 
 Style/FrozenStringLiteralComment:
-  Enabled: false
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 # Include gem dependencies from ruby-openai.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require "bundler/setup"
 require "openai"

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "faraday"
 require "faraday/multipart"
 
@@ -19,8 +21,8 @@ module OpenAI
     attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout,
                   :extra_headers
 
-    DEFAULT_API_VERSION = "v1".freeze
-    DEFAULT_URI_BASE = "https://api.openai.com/".freeze
+    DEFAULT_API_VERSION = "v1"
+    DEFAULT_URI_BASE = "https://api.openai.com/"
     DEFAULT_REQUEST_TIMEOUT = 120
 
     def initialize

--- a/lib/openai/audio.rb
+++ b/lib/openai/audio.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
   class Audio
     def initialize(client:)

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
   class Client
     include OpenAI::HTTP

--- a/lib/openai/compatibility.rb
+++ b/lib/openai/compatibility.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Ruby
   module OpenAI
     VERSION = ::OpenAI::VERSION

--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
   class Files
     def initialize(client:)

--- a/lib/openai/finetunes.rb
+++ b/lib/openai/finetunes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
   class Finetunes
     def initialize(client:)

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "event_stream_parser"
 
 module OpenAI

--- a/lib/openai/images.rb
+++ b/lib/openai/images.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
   class Images
     def initialize(client: nil)

--- a/lib/openai/models.rb
+++ b/lib/openai/models.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
   class Models
     def initialize(client:)

--- a/lib/openai/version.rb
+++ b/lib/openai/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module OpenAI
-  VERSION = "6.0.0".freeze
+  VERSION = "6.0.0"
 end

--- a/lib/ruby/openai.rb
+++ b/lib/ruby/openai.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require_relative "../openai"
 require_relative "../openai/compatibility"

--- a/ruby-openai.gemspec
+++ b/ruby-openai.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "lib/openai/version"
 
 Gem::Specification.new do |spec|

--- a/spec/compatibility_spec.rb
+++ b/spec/compatibility_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe "compatibility" do
   context "for moved constants" do
     describe "::Ruby::OpenAI::VERSION" do

--- a/spec/openai/client/audio_spec.rb
+++ b/spec/openai/client/audio_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#audio" do
     describe "#transcribe" do

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#chat" do
     context "with messages", :vcr do

--- a/spec/openai/client/client_spec.rb
+++ b/spec/openai/client/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   context "with clients with different access tokens" do
     before do

--- a/spec/openai/client/edits_spec.rb
+++ b/spec/openai/client/edits_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#edits", :vcr do
     let(:input) { "There are 7 days in a wek, and between 28 and 31 in a month." }

--- a/spec/openai/client/embeddings_spec.rb
+++ b/spec/openai/client/embeddings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#embeddings", :vcr do
     let(:input) { "The food was delicious and the waiter..." }

--- a/spec/openai/client/files_spec.rb
+++ b/spec/openai/client/files_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#files", :vcr do
     let(:filename) { "sentiment.jsonl" }

--- a/spec/openai/client/finetunes_spec.rb
+++ b/spec/openai/client/finetunes_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#finetunes", :vcr do
     let(:model) { "gpt-3.5-turbo-0613" }

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::HTTP do
   describe "with an aggressive timeout" do
     let(:timeout_errors) { [Faraday::ConnectionFailed, Faraday::TimeoutError] }

--- a/spec/openai/client/images_spec.rb
+++ b/spec/openai/client/images_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#images" do
     describe "#generate", :vcr do

--- a/spec/openai/client/models_spec.rb
+++ b/spec/openai/client/models_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#models" do
     describe "#list", :vcr do

--- a/spec/openai/client/moderations_spec.rb
+++ b/spec/openai/client/moderations_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI::Client do
   describe "#moderations", :vcr do
     let(:input) { "I'm worried about that." }

--- a/spec/openai_spec.rb
+++ b/spec/openai_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe OpenAI do
   it "has a version number" do
     expect(OpenAI::VERSION).not_to be nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require "dotenv/load"
 require "openai"
@@ -34,7 +36,7 @@ RSpec.configure do |c|
   if ENV.fetch("OPENAI_ACCESS_TOKEN", nil)
     warning = "WARNING! Specs are hitting the OpenAI API using your OPENAI_ACCESS_TOKEN! This
 costs at least 2 cents per run and is very slow! If you don't want this, unset
-OPENAI_ACCESS_TOKEN to just run against the stored VCR responses.".freeze
+OPENAI_ACCESS_TOKEN to just run against the stored VCR responses."
     warning = RSpec::Core::Formatters::ConsoleCodes.wrap(warning, :bold_red)
 
     c.before(:suite) { RSpec.configuration.reporter.message(warning) }

--- a/spec/support/vcr_multipart_matcher.rb
+++ b/spec/support/vcr_multipart_matcher.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class VCRMultipartMatcher
   MULTIPART_HEADER_MATCHER = %r{^multipart/form-data; boundary=(.+)$}.freeze
-  BOUNDARY_SUBSTITUTION = "----MultipartBoundaryAbcD3fGhiXyz00001".freeze
+  BOUNDARY_SUBSTITUTION = "----MultipartBoundaryAbcD3fGhiXyz00001"
 
   def call(request1, request2)
     return false unless same_content_type?(request1, request2)


### PR DESCRIPTION
We should enable frozen string literals by default for performance and thread safety.

I got GPT-4 to explain why they are important:

<img width="888" alt="Screenshot 2023-11-07 at 12 23 23 AM" src="https://github.com/alexrudall/ruby-openai/assets/163873/e72752dd-941c-458a-89cb-a581d8b4ab42">

Less important for new versions of Ruby, but also eliminates a bunch of `.freeze` sprinkled in the code too, which is nice. And Rubocop will automatically add them.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
