### PR TITLE
Handle case where error response body may not be JSON

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -51,7 +51,7 @@ module OpenAI
       proc do |chunk, _bytes, env|
         if env && env.status != 200
           raise_error = Faraday::Response::RaiseError.new
-          raise_error.on_complete(env.merge(body: JSON.parse(chunk)))
+          raise_error.on_complete(env.merge(body: try_parse_json(chunk)))
         end
 
         parser.feed(chunk) do |_type, data|
@@ -124,6 +124,12 @@ module OpenAI
 
       req.headers = headers
       req.body = req_parameters.to_json
+    end
+
+    def try_parse_json(maybe_json)
+      JSON.parse(maybe_json)
+    rescue JSON::ParserError
+      maybe_json
     end
   end
 end

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat_with_json_error_response.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat_with_json_error_response.yml
@@ -19,11 +19,24 @@ http_interactions:
           - Ruby
     response:
       status:
-        code: 500
-        message: Internal Server Error
+        code: 400
+        message: Bad Request
       headers:
         Date:
           - Mon, 14 Aug 2023 15:02:13 GMT
+        Content-Type:
+          - application/json
+      body:
+        encoding: UTF-8
+        string: |+
+          {
+              "error": {
+                  "message": "Test error",
+                  "type": "test_error",
+                  "param": null,
+                  "code": "test"
+              }
+          }
     recorded_at: Mon, 14 Aug 2023 15:02:13 GMT
 
 recorded_with: VCR 6.1.0

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe OpenAI::Client do
             end
           end
 
-          context "with an error response" do
-            let(:cassette) { "#{model} streamed chat with error response".downcase }
+          context "with an error response with a JSON body" do
+            let(:cassette) { "#{model} streamed chat with json error response".downcase }
 
-            it "raises an HTTP error" do
+            it "raises an HTTP error with the parsed body" do
               VCR.use_cassette(cassette, record: :none) do
                 response
               rescue Faraday::BadRequestError => e
@@ -91,6 +91,21 @@ RSpec.describe OpenAI::Client do
                                                 })
               else
                 raise "Expected to raise Faraday::BadRequestError"
+              end
+            end
+          end
+
+          context "with an error response without a JSON body" do
+            let(:cassette) { "#{model} streamed chat with error response".downcase }
+
+            it "raises an HTTP error" do
+              VCR.use_cassette(cassette, record: :none) do
+                response
+              rescue Faraday::ServerError => e
+                expect(e.response).to include(status: 500)
+                expect(e.response[:body]).to eq("")
+              else
+                raise "Expected to raise Faraday::ServerError"
               end
             end
           end


### PR DESCRIPTION
Fixes #357

Gracefully handle the case where an HTTP error response may not have valid JSON in its body e.g.:
- OpenAI is having a bad day an returns a 500 Internal Server Error
- Some other network element like a proxy is returning some 4xx or 5xx.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
