### PR TITLE
Remove file upload JSON validation

### DIFF
--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -9,8 +9,6 @@ module OpenAI
     end
 
     def upload(parameters: {})
-      validate(file: parameters[:file])
-
       @client.multipart_post(
         path: "/files",
         parameters: parameters.merge(file: File.open(parameters[:file]))
@@ -27,16 +25,6 @@ module OpenAI
 
     def delete(id:)
       @client.delete(path: "/files/#{id}")
-    end
-
-    private
-
-    def validate(file:)
-      File.open(file).each_line.with_index do |line, index|
-        JSON.parse(line)
-      rescue JSON::ParserError => e
-        raise JSON::ParserError, "#{e.message} - found on line #{index + 1} of #{file}"
-      end
     end
   end
 end

--- a/spec/openai/client/files_spec.rb
+++ b/spec/openai/client/files_spec.rb
@@ -18,12 +18,6 @@ RSpec.describe OpenAI::Client do
           expect(upload["filename"]).to eq(filename)
         end
       end
-
-      context "with an invalid file" do
-        let(:filename) { File.join("errors", "missing_quote.jsonl") }
-
-        it { expect { upload }.to raise_error(JSON::ParserError) }
-      end
     end
 
     describe "#list" do


### PR DESCRIPTION
## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

## Why?

The file upload facility is now used in more places (specifically assistants) that do not have any restrictions on the format of the data that is uploaded. This PR removes the JSON validation on uploading files.