### PR TITLE
Add a missing spec for messages#list

### DIFF
--- a/spec/fixtures/cassettes/messages_list.yml
+++ b/spec/fixtures/cassettes/messages_list.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.openai.com/v1/threads/thread_Tg0kigak0X5UW6SrbD2eqo3o/messages
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 22 Nov 2023 03:46:29 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - peggy-e1o8zu
+      X-Request-Id:
+      - adcdecda514fb4b5280ed6c69028d951
+      Openai-Processing-Ms:
+      - '80'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=1fTcEdBHf594D9mkZgF97mw6diO6QU_0CBz_SHYjLDI-1700624789-0-AZRpoGNNYrKUQHRiLVa5aRuJDJaMssHSsx79GFPbYbzXtBeDgfg1qc4f6BoAv3oU9OAC9XiHmZJRJx6TmY45X94=;
+        path=/; expires=Wed, 22-Nov-23 04:16:29 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=ddAJEOtcVE0CFbyFNqrfyJanOIOqV.fGScWJeHKYHnc-1700624789142-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 829e2f832e87a214-YYZ
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "object": "list",
+          "data": [],
+          "first_id": null,
+          "last_id": null,
+          "has_more": false
+        }
+  recorded_at: Wed, 22 Nov 2023 03:46:29 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/messages_list_thread_setup.yml
+++ b/spec/fixtures/cassettes/messages_list_thread_setup.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 22 Nov 2023 03:46:28 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - peggy-e1o8zu
+      X-Request-Id:
+      - 179dabcfc67f03c271fe8677ad5f0369
+      Openai-Processing-Ms:
+      - '75'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=gJ_PDwKwaRerebotwYAwEDqTuKNSWi0JyPxB70nYaTI-1700624788-0-AT3tY9Y6UqjepiHJUKuxSmmWo9OJapLnsrtQZoHccnw1/egY2iWaI4qs0BLHOVfSIuOV7UeYbbN3yAnKOXLV57c=;
+        path=/; expires=Wed, 22-Nov-23 04:16:28 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=3JvQ4H6yQW.wgHoc9pSUH0ispIuTjZsCvIVyDsZ.uyc-1700624788930-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 829e2f81b910a240-YYZ
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "thread_Tg0kigak0X5UW6SrbD2eqo3o",
+          "object": "thread",
+          "created_at": 1700624788,
+          "metadata": {}
+        }
+  recorded_at: Wed, 22 Nov 2023 03:46:28 GMT
+recorded_with: VCR 6.1.0

--- a/spec/openai/client/messages_spec.rb
+++ b/spec/openai/client/messages_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe OpenAI::Client do
       end
     end
 
+    describe "#list" do
+      let(:cassette) { "messages list" }
+      let(:response) do
+        OpenAI::Client.new.messages.list(thread_id: thread_id)
+      end
+
+      it "succeeds" do
+        VCR.use_cassette(cassette) do
+          expect(response["object"]).to eq("list")
+        end
+      end
+    end
+
     describe "#create" do
       let(:cassette) { "messages create" }
       let(:response) do


### PR DESCRIPTION
I noticed there's missing test coverage for `messages.list`.

This PR adds the missing spec, as well as the missing cassettes.

Tests pass and the cassette response data is authentic.

Hope this helps folks needing to better understand the response format for the `messages.list` call :)

----

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
