### PR TITLE
Teach runs list endpoints to use parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ If the `status` response indicates that the `run` is `completed`, the associated
 messages = client.messages.list(thread_id: thread_id) # Note: as of 2023-12-11 adding limit or order options isn't working, yet
 
 # Alternatively retrieve the `run steps` for the run which link to the messages:
-run_steps = client.run_steps.list(thread_id: thread_id, run_id: run_id)
+run_steps = client.run_steps.list(thread_id: thread_id, run_id: run_id, parameters: { order: 'asc' })
 new_message_ids = run_steps['data'].filter_map { |step|
   if step['type'] == 'message_creation'
     step.dig('step_details', "message_creation", "message_id")

--- a/README.md
+++ b/README.md
@@ -712,10 +712,10 @@ new_messages.each { |msg|
 }
 ```
 
-At any time you can list all runs which have been performed on a particular thread or are currently running (in descending/newest first order):
+At any time you can list all runs which have been performed on a particular thread or are currently running:
 
 ```ruby
-client.runs.list(thread_id: thread_id)
+client.runs.list(thread_id: thread_id, parameters: { order: "asc", limit: 3 })
 ```
 
 #### Create and Run

--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ If the `status` response indicates that the `run` is `completed`, the associated
 
 ```ruby
 # Either retrieve all messages in bulk again, or...
-messages = client.messages.list(thread_id: thread_id) # Note: as of 2023-12-11 adding limit or order options isn't working, yet
+messages = client.messages.list(thread_id: thread_id, parameters: { order: 'asc' })
 
 # Alternatively retrieve the `run steps` for the run which link to the messages:
 run_steps = client.run_steps.list(thread_id: thread_id, run_id: run_id, parameters: { order: 'asc' })

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -6,8 +6,8 @@ module OpenAI
   module HTTP
     include HTTPHeaders
 
-    def get(path:)
-      parse_jsonl(conn.get(uri(path: path)) do |req|
+    def get(path:, parameters: nil)
+      parse_jsonl(conn.get(uri(path: path), parameters) do |req|
         req.headers = headers
       end&.body)
     end

--- a/lib/openai/messages.rb
+++ b/lib/openai/messages.rb
@@ -4,8 +4,8 @@ module OpenAI
       @client = client.beta(assistants: "v1")
     end
 
-    def list(thread_id:)
-      @client.get(path: "/threads/#{thread_id}/messages")
+    def list(thread_id:, parameters: {})
+      @client.get(path: "/threads/#{thread_id}/messages", parameters: parameters)
     end
 
     def retrieve(thread_id:, id:)

--- a/lib/openai/run_steps.rb
+++ b/lib/openai/run_steps.rb
@@ -4,8 +4,8 @@ module OpenAI
       @client = client.beta(assistants: "v1")
     end
 
-    def list(thread_id:, run_id:)
-      @client.get(path: "/threads/#{thread_id}/runs/#{run_id}/steps")
+    def list(thread_id:, run_id:, parameters: {})
+      @client.get(path: "/threads/#{thread_id}/runs/#{run_id}/steps", parameters: parameters)
     end
 
     def retrieve(thread_id:, run_id:, id:)

--- a/lib/openai/runs.rb
+++ b/lib/openai/runs.rb
@@ -4,8 +4,8 @@ module OpenAI
       @client = client.beta(assistants: "v1")
     end
 
-    def list(thread_id:)
-      @client.get(path: "/threads/#{thread_id}/runs")
+    def list(thread_id:, parameters: {})
+      @client.get(path: "/threads/#{thread_id}/runs", parameters: parameters)
     end
 
     def retrieve(thread_id:, id:)

--- a/spec/fixtures/cassettes/messages_list.yml
+++ b/spec/fixtures/cassettes/messages_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.openai.com/v1/threads/thread_Tg0kigak0X5UW6SrbD2eqo3o/messages
+    uri: https://api.openai.com/v1/threads/thread_y5AY3BMW96gyMaCt7yVHHbb2/messages?order=asc
     body:
       encoding: US-ASCII
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Nov 2023 03:46:29 GMT
+      - Sat, 27 Apr 2024 12:17:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,25 +35,25 @@ http_interactions:
       Openai-Version:
       - '2020-10-01'
       Openai-Organization:
-      - peggy-e1o8zu
+      - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - adcdecda514fb4b5280ed6c69028d951
+      - req_4819306cdacbd0e32c49c5a5d79953f8
       Openai-Processing-Ms:
-      - '80'
+      - '89'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=1fTcEdBHf594D9mkZgF97mw6diO6QU_0CBz_SHYjLDI-1700624789-0-AZRpoGNNYrKUQHRiLVa5aRuJDJaMssHSsx79GFPbYbzXtBeDgfg1qc4f6BoAv3oU9OAC9XiHmZJRJx6TmY45X94=;
-        path=/; expires=Wed, 22-Nov-23 04:16:29 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=ZcPETcILIF6aF9wzK4ex9WDdl0wKLYOT9ZjS_o8Cr8w-1714220222-1.0.1.1-BtUmqmI.f.OaQ6pmcTW2xHz971HGTQ4zAIIUezrZnnfcNWqWroCg5MRZ54PvUdd7D5kaeQzKWZshCE4vQDMR8A;
+        path=/; expires=Sat, 27-Apr-24 12:47:02 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=ddAJEOtcVE0CFbyFNqrfyJanOIOqV.fGScWJeHKYHnc-1700624789142-0-604800000;
+      - _cfuvid=oIzhT8VXK6lrMjfe076cnGcIiI6.D0vhel2Y1UXkfco-1714220222420-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 829e2f832e87a214-YYZ
+      - 87aebf4468df1c3b-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
@@ -66,5 +66,5 @@ http_interactions:
           "last_id": null,
           "has_more": false
         }
-  recorded_at: Wed, 22 Nov 2023 03:46:29 GMT
+  recorded_at: Sat, 27 Apr 2024 12:17:02 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/messages_list_thread_setup.yml
+++ b/spec/fixtures/cassettes/messages_list_thread_setup.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 22 Nov 2023 03:46:28 GMT
+      - Sat, 27 Apr 2024 12:17:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,35 +35,35 @@ http_interactions:
       Openai-Version:
       - '2020-10-01'
       Openai-Organization:
-      - peggy-e1o8zu
+      - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - 179dabcfc67f03c271fe8677ad5f0369
+      - req_3027f7d11ba68067f478a76d111f2a18
       Openai-Processing-Ms:
-      - '75'
+      - '14'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=gJ_PDwKwaRerebotwYAwEDqTuKNSWi0JyPxB70nYaTI-1700624788-0-AT3tY9Y6UqjepiHJUKuxSmmWo9OJapLnsrtQZoHccnw1/egY2iWaI4qs0BLHOVfSIuOV7UeYbbN3yAnKOXLV57c=;
-        path=/; expires=Wed, 22-Nov-23 04:16:28 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=sUSyFrMu5pu39.IRdm4P1OVnTXwGMsQi5bagLyHSegM-1714220222-1.0.1.1-wawykkgDgaZW2mH_GUu_3flOw9z_mA7FD4ATQQWYY5LoZa7H72uU8ztaMgrOdLLHoTb9wyyl5zNkuAaAbjF5aQ;
+        path=/; expires=Sat, 27-Apr-24 12:47:02 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=3JvQ4H6yQW.wgHoc9pSUH0ispIuTjZsCvIVyDsZ.uyc-1700624788930-0-604800000;
+      - _cfuvid=C2OnAjKovRA_ETypnoCpSdalzYAbPjaRXfFFW_PSpbE-1714220222103-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 829e2f81b910a240-YYZ
+      - 87aebf42ff110c52-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "thread_Tg0kigak0X5UW6SrbD2eqo3o",
+          "id": "thread_y5AY3BMW96gyMaCt7yVHHbb2",
           "object": "thread",
-          "created_at": 1700624788,
+          "created_at": 1714220222,
           "metadata": {}
         }
-  recorded_at: Wed, 22 Nov 2023 03:46:28 GMT
+  recorded_at: Sat, 27 Apr 2024 12:17:02 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list.yml
+++ b/spec/fixtures/cassettes/run_steps_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.openai.com/v1/threads/thread_s3ncOWDjuDxWLm61OSfCX8uU/runs/run_ZfFxQLJLSCESbh5PzglAgxab/steps
+    uri: https://api.openai.com/v1/threads/thread_aF079VzvOtW4f2Y3MhYN4VR0/runs/run_PWVZEmgSwhmh8Qp9jig0YzBN/steps?order=asc
     body:
       encoding: US-ASCII
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 26 Nov 2023 11:58:53 GMT
+      - Sat, 27 Apr 2024 12:14:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,23 +37,23 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - 9984d1a3ba2e1bb6f79235b789ee1e77
+      - req_f8aa18bbfc66da142131342d365f74e3
       Openai-Processing-Ms:
-      - '80'
+      - '108'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=.9qCd018Ys.Oa29y0Y9.Ph.AlFrbnuokXJAsIiXKDcI-1700999933-0-AYofy6FifSQaNc/RYmUbopOj5QQZWsXmhmbB5zSw1cv6rIRZ7p1HmMEochJRKXBxxzGDKNhvrs65l/g4f+AI3Nw=;
-        path=/; expires=Sun, 26-Nov-23 12:28:53 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=GcCigpbWYZCAorzT.PPkNq4pyZZUnMR9SS9dxb.794g-1714220048-1.0.1.1-RPXIo3Y52NOtO07XINIGEeeEXmr8tUsSvG6.GA77mpH_nAi37vD3rBVWJuTq6W81EbxDlGx9.pSHZpl.WrbIxg;
+        path=/; expires=Sat, 27-Apr-24 12:44:08 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=42VH1C8Hg0SNkjR_o0sAK_1ujjT2sX2DiX50JdaZ2MU-1700999933568-0-604800000;
+      - _cfuvid=9x1MIxApX_tEWm_pGBweQF9R5B9nSl1OWvQoyziiJ2c-1714220048908-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1f64f7a1a220c-MAN
+      - 87aebb07ee360c57-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
@@ -66,72 +66,5 @@ http_interactions:
           "last_id": null,
           "has_more": false
         }
-  recorded_at: Sun, 26 Nov 2023 11:58:53 GMT
-- request:
-    method: get
-    uri: https://api.openai.com/v1/threads/thread_l1Cn4lwOshVZRVgvIucN8kMV/runs/run_aFZprpqo8ez6c9ijX3Iyy9Km/steps
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <OPENAI_ACCESS_TOKEN>
-      Openai-Beta:
-      - assistants=v1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Sun, 26 Nov 2023 11:59:35 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Openai-Version:
-      - '2020-10-01'
-      Openai-Organization:
-      - user-jxm65ijkzc1qrfhc0ij8moic
-      X-Request-Id:
-      - '0831452776e07ababf74fe912e3a2584'
-      Openai-Processing-Ms:
-      - '86'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-      Set-Cookie:
-      - __cf_bm=vMuOKZIR9TUNpxG5r4zohOCsLj0_lRjIevJBZpuIn3E-1700999975-0-ASUC87T/hwdzonyOQl19mrT13rhcYNybUxhS4OcEze11hhebG8zyr+MNHcdFUjH8G6YKHXKrhULfNnq6wJPgk18=;
-        path=/; expires=Sun, 26-Nov-23 12:29:35 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=K28OfS7CT5t8gZLCqoRII5bZB21H7.rIq8GjTIj..eg-1700999975857-0-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 82c1f757ab4106a2-LHR
-      Alt-Svc:
-      - h3=":443"; ma=86400
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "object": "list",
-          "data": [],
-          "first_id": null,
-          "last_id": null,
-          "has_more": false
-        }
-  recorded_at: Sun, 26 Nov 2023 11:59:35 GMT
+  recorded_at: Sat, 27 Apr 2024 12:14:08 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list_assistant_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_list_assistant_setup.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 26 Nov 2023 11:59:35 GMT
+      - Sat, 27 Apr 2024 12:14:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,39 +37,42 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - c9c44c20129606b6967d7749d3bdc813
+      - req_f9420ca752802212be53de67fd2267c6
       Openai-Processing-Ms:
-      - '204'
+      - '85'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=fzvM9YKMlGXMoniTegptmxs7xeJfy01R_YiU_f.ycaI-1700999975-0-AbR0K6HpB51VWbtiPkN7WGIOAITMXdB4vbPkPYZpwm3o7P+0nkNiZcU227pA0Z8RAt7URd0fm7qGoK2cOSDpfHs=;
-        path=/; expires=Sun, 26-Nov-23 12:29:35 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=9dRYtnZnqWSzPrPJyfe6uqLqruQ45._554lqZxU1Zl0-1714220048-1.0.1.1-LrvUqJ1r39yjmNLMeayqhkecHhi71dGhU7ab.PJ98YzHhuuiWhfvQtO0fevuctZ0Yl.7AhcJvMCIHokX2vUIlw;
+        path=/; expires=Sat, 27-Apr-24 12:44:08 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=pSBuPwJxZLlH5tl00w9DXzmK06bzi2qh7Z0d0K5pgfE-1700999975029-0-604800000;
+      - _cfuvid=jITvmF4cDWDn6NYhX675djCNpq7mSVWrPNBaMimOFC0-1714220048071-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1f751ac2d54e2-MAN
+      - 87aebb02e96d1c23-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "asst_YpKwsGa57MWS6sBlNrqfLq7Z",
+          "id": "asst_wlKaxOvOQQxitMkPyCgYDKws",
           "object": "assistant",
-          "created_at": 1700999974,
+          "created_at": 1714220047,
           "name": "OpenAI-Ruby test assistant",
           "description": null,
           "model": "gpt-4",
           "instructions": null,
           "tools": [],
+          "top_p": 1.0,
+          "temperature": 1.0,
           "file_ids": [],
-          "metadata": {}
+          "metadata": {},
+          "response_format": "auto"
         }
-  recorded_at: Sun, 26 Nov 2023 11:59:35 GMT
+  recorded_at: Sat, 27 Apr 2024 12:14:08 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list_run_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_list_run_setup.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.openai.com/v1/threads/thread_s3ncOWDjuDxWLm61OSfCX8uU/runs
+    uri: https://api.openai.com/v1/threads/thread_aF079VzvOtW4f2Y3MhYN4VR0/runs
     body:
       encoding: UTF-8
-      string: '{"assistant_id":"asst_vwKqHSTZtRSy6xZVMKR5BsOf"}'
+      string: '{"assistant_id":"asst_wlKaxOvOQQxitMkPyCgYDKws"}'
     headers:
       Content-Type:
       - application/json
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 26 Nov 2023 11:58:53 GMT
+      - Sat, 27 Apr 2024 12:14:08 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,125 +37,59 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - 25738cf620b87dc35ac717641f7923cc
+      - req_701d229c55565329ad0a45f807c1f30d
       Openai-Processing-Ms:
-      - '230'
+      - '275'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=oAZeHjc8esf1qYkL_QMuJMtrNIsYD9WUMKW4am.XN.U-1700999933-0-Aa0Ojmoh0paakAtH8nVomMtniGlAodmx5LvyAXCxd/spRdAruRh1T3W3gYLwSP6AswiUKSoZG43+PITpC80RpCo=;
-        path=/; expires=Sun, 26-Nov-23 12:28:53 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=pO5rnWQ8nWVZJKujTBR4SGwinFKEAA3uc7wKmCHBVOU-1714220048-1.0.1.1-iQbySkXHBZ8P1rACarQA5Aj_k1dhZAM9_QIHVCJIzc6QyOpxVYi3aInEwk1cHgfF3nqRC8F5iRR7wHfRZFNDjQ;
+        path=/; expires=Sat, 27-Apr-24 12:44:08 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=NIqFe3_Kmv9oSRcXzrmU68nKZpm.u6tjRUNs5Y9WjV4-1700999933277-0-604800000;
+      - _cfuvid=2TV2VXp6pXrD7FZICWX9ZMbz69P9HW0bzvMAeJE.a08-1714220048574-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1f64cbafd48b7-LHR
+      - 87aebb04cc558ee7-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "run_ZfFxQLJLSCESbh5PzglAgxab",
+          "id": "run_PWVZEmgSwhmh8Qp9jig0YzBN",
           "object": "thread.run",
-          "created_at": 1700999933,
-          "assistant_id": "asst_vwKqHSTZtRSy6xZVMKR5BsOf",
-          "thread_id": "thread_s3ncOWDjuDxWLm61OSfCX8uU",
+          "created_at": 1714220048,
+          "assistant_id": "asst_wlKaxOvOQQxitMkPyCgYDKws",
+          "thread_id": "thread_aF079VzvOtW4f2Y3MhYN4VR0",
           "status": "queued",
           "started_at": null,
-          "expires_at": 1701000533,
+          "expires_at": 1714220648,
           "cancelled_at": null,
           "failed_at": null,
           "completed_at": null,
+          "required_action": null,
           "last_error": null,
           "model": "gpt-4",
           "instructions": null,
           "tools": [],
           "file_ids": [],
-          "metadata": {}
+          "metadata": {},
+          "temperature": 1.0,
+          "top_p": 1.0,
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "truncation_strategy": {
+            "type": "auto",
+            "last_messages": null
+          },
+          "incomplete_details": null,
+          "usage": null,
+          "response_format": "auto",
+          "tool_choice": "auto"
         }
-  recorded_at: Sun, 26 Nov 2023 11:58:53 GMT
-- request:
-    method: post
-    uri: https://api.openai.com/v1/threads/thread_l1Cn4lwOshVZRVgvIucN8kMV/runs
-    body:
-      encoding: UTF-8
-      string: '{"assistant_id":"asst_YpKwsGa57MWS6sBlNrqfLq7Z"}'
-    headers:
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <OPENAI_ACCESS_TOKEN>
-      Openai-Beta:
-      - assistants=v1
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Sun, 26 Nov 2023 11:59:35 GMT
-      Content-Type:
-      - application/json
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Openai-Version:
-      - '2020-10-01'
-      Openai-Organization:
-      - user-jxm65ijkzc1qrfhc0ij8moic
-      X-Request-Id:
-      - f50b1b16b766b4b4d4bb90f285b22b89
-      Openai-Processing-Ms:
-      - '216'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Cf-Cache-Status:
-      - DYNAMIC
-      Set-Cookie:
-      - __cf_bm=plPnidQT6nC4BkHHJL.6yNqXe2BUs0j0upJ0ywN1tkU-1700999975-0-AZFbORw4Dy8qeiIZmaXqmsOjZcdj9x4LCZ5kDlDQDBTiuUo9aSCezQkV31Fu9qV8wn0/D14i+E9r4lDqXj8/XzI=;
-        path=/; expires=Sun, 26-Nov-23 12:29:35 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=f9zfUJbraM9DrUeHTbc3PIND4yMojbK36YVS6zzrPF0-1700999975491-0-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 82c1f7549a614595-LHR
-      Alt-Svc:
-      - h3=":443"; ma=86400
-    body:
-      encoding: ASCII-8BIT
-      string: |-
-        {
-          "id": "run_aFZprpqo8ez6c9ijX3Iyy9Km",
-          "object": "thread.run",
-          "created_at": 1700999975,
-          "assistant_id": "asst_YpKwsGa57MWS6sBlNrqfLq7Z",
-          "thread_id": "thread_l1Cn4lwOshVZRVgvIucN8kMV",
-          "status": "queued",
-          "started_at": null,
-          "expires_at": 1701000575,
-          "cancelled_at": null,
-          "failed_at": null,
-          "completed_at": null,
-          "last_error": null,
-          "model": "gpt-4",
-          "instructions": null,
-          "tools": [],
-          "file_ids": [],
-          "metadata": {}
-        }
-  recorded_at: Sun, 26 Nov 2023 11:59:35 GMT
+  recorded_at: Sat, 27 Apr 2024 12:14:08 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list_thread_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_list_thread_setup.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 26 Nov 2023 11:59:34 GMT
+      - Sat, 27 Apr 2024 12:14:07 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,33 +37,33 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - fad0e6bfac305dd81023dd9792837a06
+      - req_6024d553b142a10a0ea69196675925c4
       Openai-Processing-Ms:
-      - '22'
+      - '32'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=NmQ2Owpbqt.8XL_Z8mtcDlOn0u02sKIi6RtTuyTewBE-1700999974-0-AVWwD8Liih5hfykkUr7e3mfhreoKI95v3+M+ggNKTJHlkEYY2PcPuWQI+cDZ1Kp+x6PXgBiflAjGaT/RsXUzYas=;
-        path=/; expires=Sun, 26-Nov-23 12:29:34 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=WURbsUKUA8ohECJYqpOJe1dEoajvrMpKMLTUEUuIJzU-1714220047-1.0.1.1-pZYd2eNFgA5SaFg1cZavF1dKNbpdGpt8MpZuPPRBuU47tlPPtRyNUaoeuotLMmVHlFWeeL1sWAnn1qG1JUhObw;
+        path=/; expires=Sat, 27-Apr-24 12:44:07 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=AjB5nQ3PTR5qo8jiIUc1HyUGdFsVn3rwv2pRc2VtYpM-1700999974621-0-604800000;
+      - _cfuvid=sZHQftb590yoc3EWJ7LoknFHtLA47MDZEp9HOG2TeKQ-1714220047773-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1f7503a44412e-LHR
+      - 87aebb012bb20c5f-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "thread_l1Cn4lwOshVZRVgvIucN8kMV",
+          "id": "thread_aF079VzvOtW4f2Y3MhYN4VR0",
           "object": "thread",
-          "created_at": 1700999974,
+          "created_at": 1714220047,
           "metadata": {}
         }
-  recorded_at: Sun, 26 Nov 2023 11:59:34 GMT
+  recorded_at: Sat, 27 Apr 2024 12:14:07 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/runs_list.yml
+++ b/spec/fixtures/cassettes/runs_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.openai.com/v1/threads/thread_81oRXfTYfWbikQAnfM4NayFO/runs
+    uri: https://api.openai.com/v1/threads/thread_SSgXQGQfqBA8OxF4iAPea2Eu/runs?order=asc
     body:
       encoding: US-ASCII
       string: ''
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:49:27 GMT
+      - Sat, 27 Apr 2024 12:10:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,23 +37,23 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - 1da2bae31dbecfcd0787aa66fcc4b0b7
+      - req_5ac3edfcab2e7bb567baaad1a8ce906c
       Openai-Processing-Ms:
-      - '78'
+      - '108'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=AwV63pDo1YM4.zmrz8BmkdJsqVy3Wnpe0_bg8lYST0I-1699998567-0-Acsw74BgpmLBIcLNkarFCQNBXced/qlPJjh7zhYZEIla1giCZKtwKeuXlzvVuh9YL1zDDONWCKciun8xuhWupbQ=;
-        path=/; expires=Tue, 14-Nov-23 22:19:27 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=NZ8CVP_dqs_rpctkhoDNnwQzePREfQYdSNoX01CVG1Y-1714219842-1.0.1.1-BLBNEwN7rcAqQhiTXMts1OB938nGQH4RN5qtYX2TrF3bx.EqutHwmZNTpCB9nD3loIWDl.pvABedQ7VjLgN36w;
+        path=/; expires=Sat, 27-Apr-24 12:40:42 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=qwyTLLPCgbMvELwptOcr9cqytXkuR7OEagzX5MYWlgc-1699998567237-0-604800000;
+      - _cfuvid=XS2QS_xMrhkpKSdYNWlFI.m9wGrbs3zvrqTQZbW0lIk-1714219842726-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826276e3e95d071a-LHR
+      - 87aeb5ff4eca0c5b-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
@@ -63,28 +63,41 @@ http_interactions:
           "object": "list",
           "data": [
             {
-              "id": "run_1S9ZxYPpPsPn6DbsfU0rMRVq",
+              "id": "run_uV1lntTVYsCuxeuvpYARKBiW",
               "object": "thread.run",
-              "created_at": 1699998566,
-              "assistant_id": "asst_4xUb13UOceg9b7L9C5pviAf9",
-              "thread_id": "thread_81oRXfTYfWbikQAnfM4NayFO",
+              "created_at": 1714219841,
+              "assistant_id": "asst_BpT409NgPbNTFeQF2qjlVisq",
+              "thread_id": "thread_SSgXQGQfqBA8OxF4iAPea2Eu",
               "status": "in_progress",
-              "started_at": 1699998566,
-              "expires_at": 1699999166,
+              "started_at": 1714219842,
+              "expires_at": 1714220441,
               "cancelled_at": null,
               "failed_at": null,
               "completed_at": null,
+              "required_action": null,
               "last_error": null,
               "model": "gpt-4",
               "instructions": null,
               "tools": [],
               "file_ids": [],
-              "metadata": {}
+              "metadata": {},
+              "temperature": 1.0,
+              "top_p": 1.0,
+              "max_completion_tokens": null,
+              "max_prompt_tokens": null,
+              "truncation_strategy": {
+                "type": "auto",
+                "last_messages": null
+              },
+              "incomplete_details": null,
+              "usage": null,
+              "response_format": "auto",
+              "tool_choice": "auto"
             }
           ],
-          "first_id": "run_1S9ZxYPpPsPn6DbsfU0rMRVq",
-          "last_id": "run_1S9ZxYPpPsPn6DbsfU0rMRVq",
+          "first_id": "run_uV1lntTVYsCuxeuvpYARKBiW",
+          "last_id": "run_uV1lntTVYsCuxeuvpYARKBiW",
           "has_more": false
         }
-  recorded_at: Tue, 14 Nov 2023 21:49:27 GMT
+  recorded_at: Sat, 27 Apr 2024 12:10:42 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/runs_list_assistant_setup.yml
+++ b/spec/fixtures/cassettes/runs_list_assistant_setup.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:49:26 GMT
+      - Sat, 27 Apr 2024 12:10:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,39 +37,42 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - af31b717536d35ebdd3034ecc991e04e
+      - req_0a1e01f3607a5845c67a03a6ffe252b9
       Openai-Processing-Ms:
-      - '126'
+      - '76'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=DVoOhZfE0CnKAUI_BgmECp0FVyhgbUrxp4.IAKjSAVI-1699998566-0-AYD13LeG6VtTocAukWe/Jr94UCAWJVPqBsvnmYSMA03q0uGQmUYZ2m1SFlil0G2Wu/bEZGP/QJtqwUmabyuOpew=;
-        path=/; expires=Tue, 14-Nov-23 22:19:26 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=nOL7Z9ZiqTtbhBdw0jNGBcEIw88a2r4x60Ax_ha8EZY-1714219841-1.0.1.1-iUOhDZ93c9HgkG85MH.YWEtdz1XcNlFouhtjC45xu40UNf2X4MuvjBp8LyZK1eL0l4xR04f_cSRzaY53Opi1SQ;
+        path=/; expires=Sat, 27-Apr-24 12:40:41 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=jXHiYeuIiNWr_cH.1qxzNGvxOJje.qhviKDXD0mK4kY-1699998566506-0-604800000;
+      - _cfuvid=p8rMYc1oGGC8lovkMqxfSduyayOts.J4M4sCL2aKN.o-1714219841587-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826276df1c4e48cd-LHR
+      - 87aeb5f85e916e9f-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "asst_4xUb13UOceg9b7L9C5pviAf9",
+          "id": "asst_BpT409NgPbNTFeQF2qjlVisq",
           "object": "assistant",
-          "created_at": 1699998566,
+          "created_at": 1714219841,
           "name": "OpenAI-Ruby test assistant",
           "description": null,
           "model": "gpt-4",
           "instructions": null,
           "tools": [],
+          "top_p": 1.0,
+          "temperature": 1.0,
           "file_ids": [],
-          "metadata": {}
+          "metadata": {},
+          "response_format": "auto"
         }
-  recorded_at: Tue, 14 Nov 2023 21:49:26 GMT
+  recorded_at: Sat, 27 Apr 2024 12:10:41 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/runs_list_run_setup.yml
+++ b/spec/fixtures/cassettes/runs_list_run_setup.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.openai.com/v1/threads/thread_81oRXfTYfWbikQAnfM4NayFO/runs
+    uri: https://api.openai.com/v1/threads/thread_SSgXQGQfqBA8OxF4iAPea2Eu/runs
     body:
       encoding: UTF-8
-      string: '{"assistant_id":"asst_4xUb13UOceg9b7L9C5pviAf9"}'
+      string: '{"assistant_id":"asst_BpT409NgPbNTFeQF2qjlVisq"}'
     headers:
       Content-Type:
       - application/json
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:49:26 GMT
+      - Sat, 27 Apr 2024 12:10:42 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,46 +37,59 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - d2d3cd86ced4ac272cadc6bf2ca63e0d
+      - req_e139af55da0980b7f4f6343f897135ba
       Openai-Processing-Ms:
-      - '210'
+      - '276'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=J_bE4KpLmatFqEtmGfYP17hhz8jJQzd7r0nQL0JYXbM-1699998566-0-Aag8sOHZEFmImfWWDvn6oXxQpVFk6dLsEtLWohTnJFPEiq1v0B37ms3XDNyOU3yL4mAPQm0Dx1+q9FiLpSqJJQs=;
-        path=/; expires=Tue, 14-Nov-23 22:19:26 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=L7Q2kcb6.vCwS4jfUC3YGqMM8iPhBh5710EJ2FYtcsg-1714219842-1.0.1.1-c0VFEslqsJvqefw4b_WkmK5_lZxHzFhrcFCM3_XOBKX3ttV37.eGl1dH3Ssz1gUrVgsPYJzrUd2Rxe2Pa_TSwA;
+        path=/; expires=Sat, 27-Apr-24 12:40:42 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=uL.jDWA_nhlfR7Lijlzhhzt_FFb_nTjuolCjWwi6XI4-1699998566924-0-604800000;
+      - _cfuvid=_kwSqlMXEpvzbHsSp34ybr_jUYW.0bURH4Cl8s9K8qs-1714219842189-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826276e11b216527-LHR
+      - 87aeb5facdff3dc1-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "run_1S9ZxYPpPsPn6DbsfU0rMRVq",
+          "id": "run_uV1lntTVYsCuxeuvpYARKBiW",
           "object": "thread.run",
-          "created_at": 1699998566,
-          "assistant_id": "asst_4xUb13UOceg9b7L9C5pviAf9",
-          "thread_id": "thread_81oRXfTYfWbikQAnfM4NayFO",
+          "created_at": 1714219841,
+          "assistant_id": "asst_BpT409NgPbNTFeQF2qjlVisq",
+          "thread_id": "thread_SSgXQGQfqBA8OxF4iAPea2Eu",
           "status": "queued",
           "started_at": null,
-          "expires_at": 1699999166,
+          "expires_at": 1714220441,
           "cancelled_at": null,
           "failed_at": null,
           "completed_at": null,
+          "required_action": null,
           "last_error": null,
           "model": "gpt-4",
           "instructions": null,
           "tools": [],
           "file_ids": [],
-          "metadata": {}
+          "metadata": {},
+          "temperature": 1.0,
+          "top_p": 1.0,
+          "max_completion_tokens": null,
+          "max_prompt_tokens": null,
+          "truncation_strategy": {
+            "type": "auto",
+            "last_messages": null
+          },
+          "incomplete_details": null,
+          "usage": null,
+          "response_format": "auto",
+          "tool_choice": "auto"
         }
-  recorded_at: Tue, 14 Nov 2023 21:49:26 GMT
+  recorded_at: Sat, 27 Apr 2024 12:10:42 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/runs_list_thread_setup.yml
+++ b/spec/fixtures/cassettes/runs_list_thread_setup.yml
@@ -25,7 +25,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:49:26 GMT
+      - Sat, 27 Apr 2024 12:10:41 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -37,33 +37,33 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - 1a400acc3aa1024a162bb009c6ca3937
+      - req_c8bc01b326926adc5624eed8757bcb6c
       Openai-Processing-Ms:
-      - '23'
+      - '21'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=nU0WCaFQYf2BBEo9s_uSWWNgLTpWDV8vPCXe46kicWU-1699998566-0-AaQdDedSbrG/TTr8G/RzePs2WIfNXplMr2mDI6jVUbFXLw7Pn+QNP7YBJQvmDYjmGq6MpCC5AeMq1ZIvOxNElhY=;
-        path=/; expires=Tue, 14-Nov-23 22:19:26 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=ntH3jtCAKgIL_9qzP_LMIesTnv8Wc7hRpiNEDIB9vfY-1714219841-1.0.1.1-a7TYAEMRDcx2vCEOBWxoGDtvobKQ7FpM1nzKcQg5kT47EbY.Jce06Zhr8tY2EDDZb0MMkKHMmgEAhJChQoedpw;
+        path=/; expires=Sat, 27-Apr-24 12:40:41 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=4Gciu6goW44JqA1oj6EiRxjzqgkyaVy0A4LhcQD2IKw-1699998566202-0-604800000;
+      - _cfuvid=puy3keqsXjo5AsAnouvzSI2BhjeexmxxbkVn4LOoFek-1714219841295-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826276ddcb546431-LHR
+      - 87aeb5f6d9d68ef2-SOF
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "thread_81oRXfTYfWbikQAnfM4NayFO",
+          "id": "thread_SSgXQGQfqBA8OxF4iAPea2Eu",
           "object": "thread",
-          "created_at": 1699998566,
+          "created_at": 1714219841,
           "metadata": {}
         }
-  recorded_at: Tue, 14 Nov 2023 21:49:26 GMT
+  recorded_at: Sat, 27 Apr 2024 12:10:41 GMT
 recorded_with: VCR 6.1.0

--- a/spec/openai/client/messages_spec.rb
+++ b/spec/openai/client/messages_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OpenAI::Client do
     describe "#list" do
       let(:cassette) { "messages list" }
       let(:response) do
-        OpenAI::Client.new.messages.list(thread_id: thread_id)
+        OpenAI::Client.new.messages.list(thread_id: thread_id, parameters: { order: "asc" })
       end
 
       it "succeeds" do

--- a/spec/openai/client/run_steps_spec.rb
+++ b/spec/openai/client/run_steps_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe OpenAI::Client do
       let(:response) do
         OpenAI::Client.new.run_steps.list(
           thread_id: thread_id,
-          run_id: run_id
+          run_id: run_id,
+          parameters: { order: "asc" }
         )
       end
 

--- a/spec/openai/client/runs_spec.rb
+++ b/spec/openai/client/runs_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe OpenAI::Client do
     describe "#list" do
       let(:cassette) { "runs list" }
       let(:response) do
-        OpenAI::Client.new.runs.list(thread_id: thread_id)
+        OpenAI::Client.new.runs.list(thread_id: thread_id, parameters: { order: "asc" })
       end
 
       before { run_id }


### PR DESCRIPTION
## Change

Teach the `client.runs.list` endpoint about a `parameters:` kwarg. That kwarg is passed to the underlying GET request.

## Motivation

I would like to check the latest run for a thread, and it seems like the best way to do this is to list the runs for a thread limited to 1.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

