### PR TITLE
6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add ability to pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg. to enable verbose logging - thanks to [@atesgoral](
+- Add ability to pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg. to enable verbose logging - shout out to [@obie](https://github.com/obie) for pushing for this.
 - Add better error logging to the client by default.
-- Bump Event Source to v1, thank you [@atesgoral](https://github.com/atesgoral) @ Shopify for this!
+- Bump Event Source to v1, thank you [@atesgoral](https://github.com/atesgoral) @ Shopify!
 
 ## [6.2.0] - 2023-11-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0] - 2023-11-26
+
+### Added
+
+- Add ability to pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg. to enable verbose logging - thanks to [@atesgoral](
+- Add better error logging to the client by default.
+- Bump Event Source to v1, thank you [@atesgoral](https://github.com/atesgoral) @ Shopify for this!
+
 ## [6.2.0] - 2023-11-15
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-openai (6.2.0)
+    ruby-openai (6.3.0)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ end
 
 #### Verbose Logging
 
-You can pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg. to enable verbose logging:
+You can pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg. to enable verbose logging with Ruby's [Logger](https://ruby-doc.org/3.2.2/stdlibs/logger/Logger.html):
 
 ```ruby
   client = OpenAI::Client.new do |f|

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -26,6 +26,9 @@ module OpenAI
       raise e unless e.response.is_a?(Hash)
 
       logger = Logger.new($stdout)
+      logger.formatter = proc do |severity, datetime, progname, msg|
+        "\033[31mOpenAI HTTP Error (spotted in ruby-openai #{VERSION}): #{msg}\n\033[0m"
+      end
       logger.error(e.response[:body])
 
       raise e

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -21,16 +21,14 @@ module OpenAI
 
   class MiddlewareErrors < Faraday::Middleware
     def call(env)
-      begin
-        @app.call(env)
-      rescue Faraday::Error => e
-        raise e unless e.response.is_a?(Hash)
+      @app.call(env)
+    rescue Faraday::Error => e
+      raise e unless e.response.is_a?(Hash)
 
-        logger = Logger.new(STDOUT)
-        logger.error(e.response[:body])
+      logger = Logger.new($stdout)
+      logger.error(e.response[:body])
 
-        raise e
-      end
+      raise e
     end
   end
 

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -26,7 +26,7 @@ module OpenAI
       raise e unless e.response.is_a?(Hash)
 
       logger = Logger.new($stdout)
-      logger.formatter = proc do |severity, datetime, progname, msg|
+      logger.formatter = proc do |_severity, _datetime, _progname, msg|
         "\033[31mOpenAI HTTP Error (spotted in ruby-openai #{VERSION}): #{msg}\n\033[0m"
       end
       logger.error(e.response[:body])

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -19,6 +19,21 @@ module OpenAI
   class Error < StandardError; end
   class ConfigurationError < Error; end
 
+  class MiddlewareErrors < Faraday::Middleware
+    def call(env)
+      begin
+        @app.call(env)
+      rescue Faraday::Error => e
+        raise e unless e.response.is_a?(Hash)
+
+        logger = Logger.new(STDOUT)
+        logger.error(e.response[:body])
+
+        raise e
+      end
+    end
+  end
+
   class Configuration
     attr_writer :access_token
     attr_accessor :api_type, :api_version, :organization_id, :uri_base, :request_timeout,

--- a/lib/openai/compatibility.rb
+++ b/lib/openai/compatibility.rb
@@ -5,5 +5,6 @@ module Ruby
     Error = ::OpenAI::Error
     ConfigurationError = ::OpenAI::ConfigurationError
     Configuration = ::OpenAI::Configuration
+    MiddlewareErrors = ::OpenAI::MiddlewareErrors
   end
 end

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -74,6 +74,7 @@ module OpenAI
       connection = Faraday.new do |f|
         f.options[:timeout] = @request_timeout
         f.request(:multipart) if multipart
+        f.use MiddlewareErrors
         f.response :raise_error
         f.response :json
       end

--- a/lib/openai/version.rb
+++ b/lib/openai/version.rb
@@ -1,3 +1,3 @@
 module OpenAI
-  VERSION = "6.2.0".freeze
+  VERSION = "6.3.0".freeze
 end

--- a/spec/fixtures/cassettes/gpt-3_5-turbo-0301_chat.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo-0301_chat.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:48:42 GMT
+      - Sun, 26 Nov 2023 11:45:51 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -39,7 +39,7 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       Openai-Processing-Ms:
-      - '2248'
+      - '1126'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
@@ -48,44 +48,50 @@ http_interactions:
       - '3500'
       X-Ratelimit-Limit-Tokens:
       - '90000'
+      X-Ratelimit-Limit-Tokens-Usage-Based:
+      - '90000'
       X-Ratelimit-Remaining-Requests:
       - '3499'
       X-Ratelimit-Remaining-Tokens:
+      - '89980'
+      X-Ratelimit-Remaining-Tokens-Usage-Based:
       - '89980'
       X-Ratelimit-Reset-Requests:
       - 17ms
       X-Ratelimit-Reset-Tokens:
       - 12ms
+      X-Ratelimit-Reset-Tokens-Usage-Based:
+      - 12ms
       X-Request-Id:
-      - fe4f630ba8317933dd2719057a09b927
+      - 24cc3456b58b01836c03c53ce3d9a6d3
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=13FuITXX7fvz__oBPmHINTQaPwS26okxPysDeH5eYos-1699998522-0-AQvf2EPkaGO1lxiPDU6F1LBaZ0iZ6CPWD5AyizXapHj2sgFaJ0qa5KlCHIdMPDqC4B2SocBLuiheP9NOeNnz1DM=;
-        path=/; expires=Tue, 14-Nov-23 22:18:42 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=bghgrXd05E_wIaKgG5DKsuJ6sJVcNEi3C3efaeyiQVQ-1700999151-0-AfcmXOGdhxo3S6p/wLSgQggXhZ9kKbcnw3yP1Moj3SREx+enMtWPVnLn7WOaHx3FjmMCJYJcsYMp7N3N4+U29Dw=;
+        path=/; expires=Sun, 26-Nov-23 12:15:51 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=.jKpYlZ.1HTnUcWbcbb01Alb6O856fO5eSH8bKbmMEg-1699998522048-0-604800000;
+      - _cfuvid=29S6CdH9XzZCV9eAsVSGHHE5Qv00.QDH7CLKwOmw774-1700999151266-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826275bbdb905282-LHR
+      - 82c1e32f7d5963d7-LHR
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "id": "chatcmpl-8KvYtJJJJzRsSdqOcsv83LEj8sa0X",
+          "id": "chatcmpl-8P7s6GTw72U6PkhJ7XEOpcfpHpAKk",
           "object": "chat.completion",
-          "created": 1699998519,
+          "created": 1700999150,
           "model": "gpt-3.5-turbo-0301",
           "choices": [
             {
               "index": 0,
               "message": {
                 "role": "assistant",
-                "content": "Hello there, how can I assist you today?"
+                "content": "Hi there! How can I assist you today?"
               },
               "finish_reason": "stop"
             }
@@ -96,5 +102,5 @@ http_interactions:
             "total_tokens": 20
           }
         }
-  recorded_at: Tue, 14 Nov 2023 21:48:42 GMT
+  recorded_at: Sun, 26 Nov 2023 11:45:51 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_chat.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_chat.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:48:30 GMT
+      - Sun, 26 Nov 2023 11:45:46 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -39,7 +39,7 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       Openai-Processing-Ms:
-      - '1662'
+      - '1065'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
@@ -48,53 +48,59 @@ http_interactions:
       - '3500'
       X-Ratelimit-Limit-Tokens:
       - '90000'
+      X-Ratelimit-Limit-Tokens-Usage-Based:
+      - '90000'
       X-Ratelimit-Remaining-Requests:
       - '3499'
       X-Ratelimit-Remaining-Tokens:
+      - '89980'
+      X-Ratelimit-Remaining-Tokens-Usage-Based:
       - '89980'
       X-Ratelimit-Reset-Requests:
       - 17ms
       X-Ratelimit-Reset-Tokens:
       - 12ms
+      X-Ratelimit-Reset-Tokens-Usage-Based:
+      - 12ms
       X-Request-Id:
-      - e3520117a6c185aa497b476a931903cf
+      - d37ce9eab44ed35275edd3b48ca62658
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=qQOyENJW_eMpzuqZJ57HPTI7sZrdLVjmgF_crkqlLPw-1699998510-0-AfIHAG3xZQaskSUQ1I/rQ7IqkXtEoFrmAySx9Ph4jKw5OW9bH6vzkHWZcIqWJQ51RdW9AhwehFKiTGYKf/wTvEA=;
-        path=/; expires=Tue, 14-Nov-23 22:18:30 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=t5cjgUFXiv4smAMyVqtkvyjgUqtWI12P3KwdcCNWWPE-1700999146-0-AZrnb61s7Beqt7IWtGc2F+R6EcaSQIre1HQ3qFHpIX6F04X1O7gAXUpmrXRZcckYyGg2+EbiYxyTffwXeJ8Wj5o=;
+        path=/; expires=Sun, 26-Nov-23 12:15:46 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=GPagzY9uDe90wGR6AjsRioJ5kPjvnNdqdquXvCVbk.M-1699998510459-0-604800000;
+      - _cfuvid=XWD1z994UxUkiiIubJP2882wWnegMFdWWDQXy4qf4LQ-1700999146632-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826275763b3f6383-LHR
+      - 82c1e3120f500acb-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "id": "chatcmpl-8KvYiZvO6tf1mfgE7oMEpjzcf1XCu",
+          "id": "chatcmpl-8P7s1c2QVZW1Uqqd11S0cB78LBvoA",
           "object": "chat.completion",
-          "created": 1699998508,
+          "created": 1700999145,
           "model": "gpt-3.5-turbo-0613",
           "choices": [
             {
               "index": 0,
               "message": {
                 "role": "assistant",
-                "content": "Hello! How can I assist you today?"
+                "content": "Hi there! How can I assist you today?"
               },
               "finish_reason": "stop"
             }
           ],
           "usage": {
             "prompt_tokens": 9,
-            "completion_tokens": 9,
-            "total_tokens": 18
+            "completion_tokens": 10,
+            "total_tokens": 19
           }
         }
-  recorded_at: Tue, 14 Nov 2023 21:48:30 GMT
+  recorded_at: Sun, 26 Nov 2023 11:45:46 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_function_call_chat.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_function_call_chat.yml
@@ -24,87 +24,6 @@ http_interactions:
       message: Bad Request
     headers:
       Date:
-      - Wed, 15 Nov 2023 20:19:09 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '203'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Origin:
-      - "*"
-      Openai-Organization:
-      - user-jxm65ijkzc1qrfhc0ij8moic
-      Openai-Processing-Ms:
-      - '7'
-      Openai-Version:
-      - '2020-10-01'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Ratelimit-Limit-Requests:
-      - '3500'
-      X-Ratelimit-Limit-Tokens:
-      - '90000'
-      X-Ratelimit-Remaining-Requests:
-      - '3499'
-      X-Ratelimit-Remaining-Tokens:
-      - '89980'
-      X-Ratelimit-Reset-Requests:
-      - 17ms
-      X-Ratelimit-Reset-Tokens:
-      - 12ms
-      X-Request-Id:
-      - fff8500511f92af801389c10ad05191e
-      Cf-Cache-Status:
-      - DYNAMIC
-      Set-Cookie:
-      - __cf_bm=O4rAlTWDniPVp3kcpgj4f7fP79xiWLNCQoAMoSG5pZI-1700079549-0-AV+FZEbxwthZ9Icys3JgIg0eDc2QTlN9EAQC8c9LdSp0EAS1Sa3GPz86miQNlrphFK9XtLaxP4GxSLC9PZ/ewlg=;
-        path=/; expires=Wed, 15-Nov-23 20:49:09 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=7yZmgufX5bXWjGFkNKw8OFFxUs.juyHjh5S.A3NNJog-1700079549948-0-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
-      Server:
-      - cloudflare
-      Cf-Ray:
-      - 826a3001aa670ac3-MAN
-      Alt-Svc:
-      - h3=":443"; ma=86400
-    body:
-      encoding: UTF-8
-      string: |
-        {
-          "error": {
-            "message": "Missing parameter 'name': messages with role 'function' must have a 'name'.",
-            "type": "invalid_request_error",
-            "param": "messages.[0].name",
-            "code": null
-          }
-        }
-  recorded_at: Wed, 15 Nov 2023 20:19:09 GMT
-- request:
-    method: post
-    uri: https://api.openai.com/v1/chat/completions
-    body:
-      encoding: UTF-8
-      string: '{"model":"gpt-3.5-turbo","messages":[{"role":"function","content":"function"}],"functions":[{"name":"function","description":"function","parameters":{"type":"object","properties":{"user":{"type":"string","description":"the
-        full name of the user"}}}}],"stream":false}'
-    headers:
-      Content-Type:
-      - application/json
-      Authorization:
-      - Bearer <OPENAI_ACCESS_TOKEN>
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Date:
       - Wed, 15 Nov 2023 20:25:14 GMT
       Content-Type:
       - application/json
@@ -162,4 +81,91 @@ http_interactions:
           }
         }
   recorded_at: Wed, 15 Nov 2023 20:25:14 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-3.5-turbo","messages":[{"role":"function","content":"function"}],"stream":false,"functions":[{"name":"function","description":"function","parameters":{"type":"object","properties":{"user":{"type":"string","description":"the
+        full name of the user"}}}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 11:45:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '203'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      Openai-Processing-Ms:
+      - '7'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Ratelimit-Limit-Requests:
+      - '3500'
+      X-Ratelimit-Limit-Tokens:
+      - '90000'
+      X-Ratelimit-Limit-Tokens-Usage-Based:
+      - '90000'
+      X-Ratelimit-Remaining-Requests:
+      - '3499'
+      X-Ratelimit-Remaining-Tokens:
+      - '89980'
+      X-Ratelimit-Remaining-Tokens-Usage-Based:
+      - '89980'
+      X-Ratelimit-Reset-Requests:
+      - 17ms
+      X-Ratelimit-Reset-Tokens:
+      - 12ms
+      X-Ratelimit-Reset-Tokens-Usage-Based:
+      - 12ms
+      X-Request-Id:
+      - 918f7bf767b8126da2bb8cf5aace7bdc
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=Re6St3HN.tm6u8vxnVJ9sN4SKOW2_7ECkYM8m__KGok-1700999146-0-AcT7djUiFezG8x2F+aGJ9W/uCyaj1O3kfAem1XrFUMxe+xn0RubWqWPAQgspMaa5853nBkZbuqWEde+BjIXcLLQ=;
+        path=/; expires=Sun, 26-Nov-23 12:15:46 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=3mjQ_b2n4nnQA47KIzgL4PS6tzdsYBDlSER9hOogr7E-1700999146898-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1e31b0d6a065e-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "Missing parameter 'name': messages with role 'function' must have a 'name'.",
+            "type": "invalid_request_error",
+            "param": "messages.[0].name",
+            "code": null
+          }
+        }
+  recorded_at: Sun, 26 Nov 2023 11:45:46 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:48:36 GMT
+      - Sun, 26 Nov 2023 11:45:48 GMT
       Content-Type:
       - text/event-stream
       Transfer-Encoding:
@@ -39,7 +39,7 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       Openai-Processing-Ms:
-      - '5602'
+      - '1240'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
@@ -48,58 +48,62 @@ http_interactions:
       - '3500'
       X-Ratelimit-Limit-Tokens:
       - '90000'
+      X-Ratelimit-Limit-Tokens-Usage-Based:
+      - '90000'
       X-Ratelimit-Remaining-Requests:
       - '3499'
       X-Ratelimit-Remaining-Tokens:
+      - '89980'
+      X-Ratelimit-Remaining-Tokens-Usage-Based:
       - '89980'
       X-Ratelimit-Reset-Requests:
       - 17ms
       X-Ratelimit-Reset-Tokens:
       - 12ms
+      X-Ratelimit-Reset-Tokens-Usage-Based:
+      - 12ms
       X-Request-Id:
-      - 916d122264202df63525050b4f269d31
+      - 877d4b998f02ae82607a1174162fd903
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=OjS.Ik.qIWH0gEqRn6Jhjoke3CHTLUDvszvE3ULpirs-1699998516-0-Ae/6IivWiQxtwITHax1AeTSjIjeq3ff6NRcD5ly1Cqi4pJ2P8ggFQu/XdfqtvkjeXPUQCL/V7PWC4Ehtufdb2jw=;
-        path=/; expires=Tue, 14-Nov-23 22:18:36 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=QBsTItLOWFOuLdT84rZgWdFmkcuduCX4F7is7JPDRvg-1700999148-0-ARW1n9o2cUEXay55MfzAxEbi2zCU3a5B91jHZpgDs8ZymjHmXFoJx60YVc/ZYBnUHaOYZRauxkvRPBz6mgdqWM8=;
+        path=/; expires=Sun, 26-Nov-23 12:15:48 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=VTNiaSvgZ8bmYcT2_ugH0w5xa159lK2WBE6pc7o9H3k-1699998516338-0-604800000;
+      - _cfuvid=oQAgNsnD9d5.heP1jTJGhkoHZT1cq3p15CXsUEqiXR0-1700999148461-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82627582f8d90672-LHR
+      - 82c1e31c9b563601-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: UTF-8
       string: |+
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" there"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" How"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" How"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" can"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" can"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" I"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" I"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" assist"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" assist"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" you"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" you"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" today"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" today"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"?"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"?"},"finish_reason":null}]}
-
-        data: {"id":"chatcmpl-8KvYkXiLeJRAyNlKbe90EgN4cvbi0","object":"chat.completion.chunk","created":1699998510,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+        data: {"id":"chatcmpl-8P7s3sDocXsBE8nhq60IMx3WFu4B8","object":"chat.completion.chunk","created":1700999147,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
 
         data: [DONE]
 
-  recorded_at: Tue, 14 Nov 2023 21:48:37 GMT
+  recorded_at: Sun, 26 Nov 2023 11:45:48 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat_without_proc.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_streamed_chat_without_proc.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:48:37 GMT
+      - Sun, 26 Nov 2023 11:45:49 GMT
       Content-Type:
       - text/event-stream
       Transfer-Encoding:
@@ -39,7 +39,7 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       Openai-Processing-Ms:
-      - '279'
+      - '136'
       Openai-Version:
       - '2020-10-01'
       Strict-Transport-Security:
@@ -48,58 +48,62 @@ http_interactions:
       - '3500'
       X-Ratelimit-Limit-Tokens:
       - '90000'
+      X-Ratelimit-Limit-Tokens-Usage-Based:
+      - '90000'
       X-Ratelimit-Remaining-Requests:
       - '3499'
       X-Ratelimit-Remaining-Tokens:
+      - '89980'
+      X-Ratelimit-Remaining-Tokens-Usage-Based:
       - '89980'
       X-Ratelimit-Reset-Requests:
       - 17ms
       X-Ratelimit-Reset-Tokens:
       - 12ms
+      X-Ratelimit-Reset-Tokens-Usage-Based:
+      - 12ms
       X-Request-Id:
-      - 7c4df6449293fb8d895adb3c5f6cadfa
+      - bb37f7f95f514fb2d0c2ab3dfd0af26a
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=UxHWDTYPg6So94iic71hpmpPi9I2sz8RZr4Xn2nI60w-1699998517-0-AQyKxPgKpOs+sheXYvt4jSRP+5kJcWMYNBHtEgu+rFKQe7BEjvhYeZkhbkCTihbM8NacKkO/I1U4c85sIn/aE04=;
-        path=/; expires=Tue, 14-Nov-23 22:18:37 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=4GK0U7v2L2zqKIR2RX9l6aoxhD8oGd2TPJjFG1z9RMc-1700999149-0-AafVGgf0Uv5Ct7Jc+2kaextmTKBd54t0xF1g4uj7z6YPwc1wkJph1WVdrIJes0OfH9ilHz/u5Btj8qhk/LjAv9s=;
+        path=/; expires=Sun, 26-Nov-23 12:15:49 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=5.Vd88HZSAQCKTQ9ajJO4mAQyAOpFqEbUOUd15cB1Yw-1699998517982-0-604800000;
+      - _cfuvid=S3hJG_pJcZ1c.k2tyxYd2rfc9ORawKddovBPKD3uqVU-1700999149240-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 826275ad2c1d8926-LHR
+      - 82c1e3271bff54cf-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: UTF-8
       string: |+
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" there"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"!"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" How"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" How"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" can"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" can"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" I"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" I"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" assist"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" assist"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" you"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" you"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" today"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":" today"},"finish_reason":null}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"?"},"finish_reason":null}]}
 
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{"content":"?"},"finish_reason":null}]}
-
-        data: {"id":"chatcmpl-8KvYr7HY6Gueh7oro6zCPikn231kg","object":"chat.completion.chunk","created":1699998517,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+        data: {"id":"chatcmpl-8P7s4yEuI67Lv6U8oqZXOFKBrNjBT","object":"chat.completion.chunk","created":1700999148,"model":"gpt-3.5-turbo-0613","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
 
         data: [DONE]
 
-  recorded_at: Tue, 14 Nov 2023 21:48:39 GMT
+  recorded_at: Sun, 26 Nov 2023 11:45:49 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list_assistant_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_list_assistant_setup.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/assistants
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4","name":"OpenAI-Ruby test assistant"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 11:59:35 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - c9c44c20129606b6967d7749d3bdc813
+      Openai-Processing-Ms:
+      - '204'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=fzvM9YKMlGXMoniTegptmxs7xeJfy01R_YiU_f.ycaI-1700999975-0-AbR0K6HpB51VWbtiPkN7WGIOAITMXdB4vbPkPYZpwm3o7P+0nkNiZcU227pA0Z8RAt7URd0fm7qGoK2cOSDpfHs=;
+        path=/; expires=Sun, 26-Nov-23 12:29:35 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=pSBuPwJxZLlH5tl00w9DXzmK06bzi2qh7Z0d0K5pgfE-1700999975029-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1f751ac2d54e2-MAN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "asst_YpKwsGa57MWS6sBlNrqfLq7Z",
+          "object": "assistant",
+          "created_at": 1700999974,
+          "name": "OpenAI-Ruby test assistant",
+          "description": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 11:59:35 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list_run_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_list_run_setup.yml
@@ -1,11 +1,11 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.openai.com/v1/threads/thread_s3ncOWDjuDxWLm61OSfCX8uU/runs/run_ZfFxQLJLSCESbh5PzglAgxab/steps
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_s3ncOWDjuDxWLm61OSfCX8uU/runs
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_vwKqHSTZtRSy6xZVMKR5BsOf"}'
     headers:
       Content-Type:
       - application/json
@@ -37,42 +37,54 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - 9984d1a3ba2e1bb6f79235b789ee1e77
+      - 25738cf620b87dc35ac717641f7923cc
       Openai-Processing-Ms:
-      - '80'
+      - '230'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=.9qCd018Ys.Oa29y0Y9.Ph.AlFrbnuokXJAsIiXKDcI-1700999933-0-AYofy6FifSQaNc/RYmUbopOj5QQZWsXmhmbB5zSw1cv6rIRZ7p1HmMEochJRKXBxxzGDKNhvrs65l/g4f+AI3Nw=;
+      - __cf_bm=oAZeHjc8esf1qYkL_QMuJMtrNIsYD9WUMKW4am.XN.U-1700999933-0-Aa0Ojmoh0paakAtH8nVomMtniGlAodmx5LvyAXCxd/spRdAruRh1T3W3gYLwSP6AswiUKSoZG43+PITpC80RpCo=;
         path=/; expires=Sun, 26-Nov-23 12:28:53 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=42VH1C8Hg0SNkjR_o0sAK_1ujjT2sX2DiX50JdaZ2MU-1700999933568-0-604800000;
+      - _cfuvid=NIqFe3_Kmv9oSRcXzrmU68nKZpm.u6tjRUNs5Y9WjV4-1700999933277-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1f64f7a1a220c-MAN
+      - 82c1f64cbafd48b7-LHR
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "object": "list",
-          "data": [],
-          "first_id": null,
-          "last_id": null,
-          "has_more": false
+          "id": "run_ZfFxQLJLSCESbh5PzglAgxab",
+          "object": "thread.run",
+          "created_at": 1700999933,
+          "assistant_id": "asst_vwKqHSTZtRSy6xZVMKR5BsOf",
+          "thread_id": "thread_s3ncOWDjuDxWLm61OSfCX8uU",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000533,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
         }
   recorded_at: Sun, 26 Nov 2023 11:58:53 GMT
 - request:
-    method: get
-    uri: https://api.openai.com/v1/threads/thread_l1Cn4lwOshVZRVgvIucN8kMV/runs/run_aFZprpqo8ez6c9ijX3Iyy9Km/steps
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_l1Cn4lwOshVZRVgvIucN8kMV/runs
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_YpKwsGa57MWS6sBlNrqfLq7Z"}'
     headers:
       Content-Type:
       - application/json
@@ -104,34 +116,46 @@ http_interactions:
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - '0831452776e07ababf74fe912e3a2584'
+      - f50b1b16b766b4b4d4bb90f285b22b89
       Openai-Processing-Ms:
-      - '86'
+      - '216'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=vMuOKZIR9TUNpxG5r4zohOCsLj0_lRjIevJBZpuIn3E-1700999975-0-ASUC87T/hwdzonyOQl19mrT13rhcYNybUxhS4OcEze11hhebG8zyr+MNHcdFUjH8G6YKHXKrhULfNnq6wJPgk18=;
+      - __cf_bm=plPnidQT6nC4BkHHJL.6yNqXe2BUs0j0upJ0ywN1tkU-1700999975-0-AZFbORw4Dy8qeiIZmaXqmsOjZcdj9x4LCZ5kDlDQDBTiuUo9aSCezQkV31Fu9qV8wn0/D14i+E9r4lDqXj8/XzI=;
         path=/; expires=Sun, 26-Nov-23 12:29:35 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=K28OfS7CT5t8gZLCqoRII5bZB21H7.rIq8GjTIj..eg-1700999975857-0-604800000;
+      - _cfuvid=f9zfUJbraM9DrUeHTbc3PIND4yMojbK36YVS6zzrPF0-1700999975491-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1f757ab4106a2-LHR
+      - 82c1f7549a614595-LHR
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "object": "list",
-          "data": [],
-          "first_id": null,
-          "last_id": null,
-          "has_more": false
+          "id": "run_aFZprpqo8ez6c9ijX3Iyy9Km",
+          "object": "thread.run",
+          "created_at": 1700999975,
+          "assistant_id": "asst_YpKwsGa57MWS6sBlNrqfLq7Z",
+          "thread_id": "thread_l1Cn4lwOshVZRVgvIucN8kMV",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000575,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
         }
   recorded_at: Sun, 26 Nov 2023 11:59:35 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_list_thread_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_list_thread_setup.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 11:59:34 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - fad0e6bfac305dd81023dd9792837a06
+      Openai-Processing-Ms:
+      - '22'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=NmQ2Owpbqt.8XL_Z8mtcDlOn0u02sKIi6RtTuyTewBE-1700999974-0-AVWwD8Liih5hfykkUr7e3mfhreoKI95v3+M+ggNKTJHlkEYY2PcPuWQI+cDZ1Kp+x6PXgBiflAjGaT/RsXUzYas=;
+        path=/; expires=Sun, 26-Nov-23 12:29:34 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=AjB5nQ3PTR5qo8jiIUc1HyUGdFsVn3rwv2pRc2VtYpM-1700999974621-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1f7503a44412e-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "thread_l1Cn4lwOshVZRVgvIucN8kMV",
+          "object": "thread",
+          "created_at": 1700999974,
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 11:59:34 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_retrieve.yml
+++ b/spec/fixtures/cassettes/run_steps_retrieve.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.openai.com/v1/threads/thread_vd1d6cmJiUkTigpDbCMKBwry/runs/run_kINaLRxQg4uZItMP0ExgGwAl/steps/step_BM4yN3TSI1mm2dbAwHUD0ATS
+    uri: https://api.openai.com/v1/threads/thread_164oz7o2wD9TP2LUri9GTGZT/runs/run_dI7saeH3pEMsJ1Ac2Cp7hHgO/steps/123
     body:
       encoding: US-ASCII
       string: ''
@@ -21,11 +21,11 @@ http_interactions:
       - Ruby
   response:
     status:
-      code: 200
-      message: OK
+      code: 404
+      message: Not Found
     headers:
       Date:
-      - Fri, 10 Nov 2023 03:12:26 GMT
+      - Sun, 26 Nov 2023 12:00:19 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,48 +35,309 @@ http_interactions:
       Openai-Version:
       - '2020-10-01'
       Openai-Organization:
-      - relay-platform
+      - user-jxm65ijkzc1qrfhc0ij8moic
       X-Request-Id:
-      - c98d26e1e592cc5ed61bdc178256cb8b
+      - cf25f51bb210ec1bce1b64f148000996
       Openai-Processing-Ms:
-      - '134'
+      - '77'
       Strict-Transport-Security:
       - max-age=15724800; includeSubDomains
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=Z8upcI8apeWDnihcDWKkTByN2a0A8rkiqgqiLSmP3bU-1699585946-0-AWqxZabRgRqQdQ1wpen84Q4/Zpuol1aP+qOmFuKwZv8Pua7C4WB7p99PsYITOMjv4VTmvf2QzVsoI3cgUbTl/pg=;
-        path=/; expires=Fri, 10-Nov-23 03:42:26 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=gnheA7sk0tLrvmmDCp9WdwqEXgvn9y6pm3nOuTP.NkI-1701000019-0-AYrDCUGv5F5g14Gt8b4RFTcoiEkqGn7R5qpq5i1EGZ/iruqzqBAQ829upBrUn8b9bydyTeeRQkq2knj+O9NKz+U=;
+        path=/; expires=Sun, 26-Nov-23 12:30:19 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
+      - _cfuvid=A76oQccwnP0i3DmzdiyFi_AhAxlnQ9lHYSeHKF.05co-1701000019197-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 823b1d21c9f1a229-YYZ
+      - 82c1f866b9da53a2-LHR
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |-
         {
-          "id": "step_BM4yN3TSI1mm2dbAwHUD0ATS",
-          "object": "thread.run.step",
-          "created_at": 1699412073,
-          "run_id": "run_kINaLRxQg4uZItMP0ExgGwAl",
-          "assistant_id": "asst_SGTQseRVgIIasVsVHPDtQNis",
-          "thread_id": "thread_vd1d6cmJiUkTigpDbCMKBwry",
-          "type": "message_creation",
-          "status": "completed",
-          "cancelled_at": null,
-          "completed_at": 1699412111,
-          "expires_at": null,
-          "failed_at": null,
-          "last_error": null,
-          "step_details": {
-            "type": "message_creation",
-            "message_creation": {
-              "message_id": "msg_BQftVtMEnkvjJexPfj2jbm3m"
-            }
+          "error": {
+            "message": "No run step found with id '123'.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": null
           }
         }
-  recorded_at: Fri, 10 Nov 2023 03:12:26 GMT
+  recorded_at: Sun, 26 Nov 2023 12:00:19 GMT
+- request:
+    method: get
+    uri: https://api.openai.com/v1/threads/thread_EgHf9xlB9MUhnzIMmjGNMh9T/runs/run_ItUrVgh28pozCrROc029nu3W/steps/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:00:56 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - 171817b6ecdfc774b7c05a7778742d96
+      Openai-Processing-Ms:
+      - '81'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=2oDn8mkWxDzA7WS7UdLKbu37lXGdT4PAIBzGTjIqk20-1701000056-0-AUC4q/p3hQfgHwiktSJinmT6hHryZEmE1VW7uBdEz2Wgc3vBuEdXrS1JCS8cmo6zfGKa8KpxEB56ip2uNnYa2UE=;
+        path=/; expires=Sun, 26-Nov-23 12:30:56 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=dJYniJ43OhgIhmBgHhBd_.h5bV3Ii5kKxZeNWUk6dO0-1701000056080-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1f94d186add7a-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "error": {
+            "message": "No run step found with id '123'.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": null
+          }
+        }
+  recorded_at: Sun, 26 Nov 2023 12:00:56 GMT
+- request:
+    method: get
+    uri: https://api.openai.com/v1/threads/thread_HiVpI7w8yCtxT9kWf3vgbPza/runs/run_W66K96hZ64q1ruAWUUmuCw1h/steps/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:01:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - 4e0fc0e5335f175b6936304c5cb3175e
+      Openai-Processing-Ms:
+      - '78'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=8S3MjnMWsn8LDCtg6M7qLFP1MMg9YKYEQsZV6TmdQvE-1701000102-0-AYFk5ewKqAnw3htz3Z5r31YMwSfd0XYTOtm4BHRqBSbpInrhR+/mTBvHtxbcqrCgUA8RB7LO5TAKgMUiWRHNjt4=;
+        path=/; expires=Sun, 26-Nov-23 12:31:42 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=1vn4MO7tETnvmupO0DNJDMqShpZMjzx0awtFE0UloXs-1701000102935-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fa720b4471db-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "error": {
+            "message": "No run step found with id '123'.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": null
+          }
+        }
+  recorded_at: Sun, 26 Nov 2023 12:01:42 GMT
+- request:
+    method: get
+    uri: https://api.openai.com/v1/threads/thread_PkpWQxrWRbk3oIgMRjsucrhG/runs/run_1blECdpYHFqbesLVuScD6dcK/steps/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:01:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - a91d35404a7f3ff2c3f6c94a5d361a7a
+      Openai-Processing-Ms:
+      - '84'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=14JGwNQ6XLRdi6WOQ6870pBqvVR1kDF23td974Uj5Fw-1701000115-0-ASC1O+whl1FEFSm3ZFRAAwilJ4r2wdjLApxaAi9m4Otqo51urrFb71vf315sHpNdzWtvUuUCQsuxmomEyL5nPa4=;
+        path=/; expires=Sun, 26-Nov-23 12:31:55 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=omfiyP8XjefkZgGLDr2q9IBvvwZxqOVc6h2G8nDwCak-1701000115250-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fabeff0edd7c-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "error": {
+            "message": "No run step found with id '123'.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": null
+          }
+        }
+  recorded_at: Sun, 26 Nov 2023 12:01:55 GMT
+- request:
+    method: get
+    uri: https://api.openai.com/v1/threads/thread_bR60V4ambvZEHqHDXXgnmDCr/runs/run_NAjX6p4waHWOiPvmqDHscA6e/steps/123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:03:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - 6f65c0a0f2fe083a5224b830e41591ae
+      Openai-Processing-Ms:
+      - '87'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=yKLgelGgVU_f0ReQBG9r4mMyxZXV9oSA7Hp2wqoA__I-1701000206-0-AQXVOG1/2csM4P8dkli7Wf3HxC2aWispBQd1gmteIHR6PCraTtAkxFOuht0HGHqv2sgXGaNXyXvGMCDT2wGKhoM=;
+        path=/; expires=Sun, 26-Nov-23 12:33:26 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=B6ershxNREf4Tirzk7xZVZlkK_aDjstKfTamlkFdtbA-1701000206734-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fcfaae896349-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "error": {
+            "message": "No run step found with id '123'.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": null
+          }
+        }
+  recorded_at: Sun, 26 Nov 2023 12:03:26 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_retrieve_assistant_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_retrieve_assistant_setup.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/assistants
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4","name":"OpenAI-Ruby test assistant"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:03:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - 834820e6d5581eeed747b5f68bf5e93d
+      Openai-Processing-Ms:
+      - '78'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=gPv2VQf8Nxo5ZJVyHCKD7b3f0O8sfokcS5yRV3iZ63U-1701000206-0-AQSm94kwAg0078jMrvuXbtKSnu9zWeJvnXgLMzTWW75MPjrkbvqQy+doCzbt9Ogw034/Xko70Vele9gvgPjMe4c=;
+        path=/; expires=Sun, 26-Nov-23 12:33:26 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=qL401iFqCN..HKY6TtiTzELukKGkunswLhpXoeSF1SM-1701000206022-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fcf63dabdd54-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "asst_f62h3HTHAgj8wxU1XsOsbhdD",
+          "object": "assistant",
+          "created_at": 1701000205,
+          "name": "OpenAI-Ruby test assistant",
+          "description": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:03:26 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_retrieve_run_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_retrieve_run_setup.yml
@@ -1,0 +1,398 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_164oz7o2wD9TP2LUri9GTGZT/runs
+    body:
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_kUJ9TeWbiauEub1V4W5o5PLC"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:00:18 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - d7a4e426377ba508ba55f4e55bf732f8
+      Openai-Processing-Ms:
+      - '222'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=ZhjfEH6b6XFWPY7.ymP9o5FyOE6Oq2itPL3nej7fLFI-1701000018-0-AeY02jC2CpS9mb5ECW/UIcobVdKmBPQpZ6SUlnzam7hFLwP2ZvVpnOzv2ycnnDBiIQ9TFl8BDWCKku6zjMpoZ10=;
+        path=/; expires=Sun, 26-Nov-23 12:30:18 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=4Kj6hZur4POObSw.YW6GjZNEIzkz3Ed893ZWoPveyxg-1701000018927-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1f8641e6c53a2-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "run_dI7saeH3pEMsJ1Ac2Cp7hHgO",
+          "object": "thread.run",
+          "created_at": 1701000018,
+          "assistant_id": "asst_kUJ9TeWbiauEub1V4W5o5PLC",
+          "thread_id": "thread_164oz7o2wD9TP2LUri9GTGZT",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000618,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:00:18 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_EgHf9xlB9MUhnzIMmjGNMh9T/runs
+    body:
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_2JR6KrGQYnOlYRouIFCeg6kT"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:00:55 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - 917dc396261903ed54631696327954bd
+      Openai-Processing-Ms:
+      - '213'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=ybkekuJUSBh1x26JHkz67Nxlja0dxAyfsRlPNEgepgs-1701000055-0-Aem5sMqVXYWshQ/Kg2HFLyzE3sl7E6plDAdN6nVdSam16Z9oUwdxeqLPjk/MlKaSdn/vSwkDlVpNmGvvd9KfEsU=;
+        path=/; expires=Sun, 26-Nov-23 12:30:55 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=fdtLh6Ih.vAfb62gL4LFXf285MO0F5jpDp1kw7lVh7c-1701000055738-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1f94a2ecf6331-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "run_ItUrVgh28pozCrROc029nu3W",
+          "object": "thread.run",
+          "created_at": 1701000055,
+          "assistant_id": "asst_2JR6KrGQYnOlYRouIFCeg6kT",
+          "thread_id": "thread_EgHf9xlB9MUhnzIMmjGNMh9T",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000655,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:00:55 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_HiVpI7w8yCtxT9kWf3vgbPza/runs
+    body:
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_KLD9j4oBeo7KrpXMMYpBxvPM"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:01:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - f80e2006c0e60b6e4b69168ebc7dc14f
+      Openai-Processing-Ms:
+      - '219'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=CNJXonniKZWdnTIaq20A7ZAydHBHVaXktOAWjKymrZ4-1701000102-0-AdICzl9NRfXPEBEKWPNsp1wdCBjK/IqN+hUsB18TzW3obQ1sW5u/RV09D9j/L9ZfQ3LCp/8ByHyIXEQ+9QpvVBA=;
+        path=/; expires=Sun, 26-Nov-23 12:31:42 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=VqxJ9AKT9eefa.na5IaqROI0eXt2k64Db17JZHgYxoA-1701000102647-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fa6f49efdcf7-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "run_W66K96hZ64q1ruAWUUmuCw1h",
+          "object": "thread.run",
+          "created_at": 1701000102,
+          "assistant_id": "asst_KLD9j4oBeo7KrpXMMYpBxvPM",
+          "thread_id": "thread_HiVpI7w8yCtxT9kWf3vgbPza",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000702,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:01:42 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_PkpWQxrWRbk3oIgMRjsucrhG/runs
+    body:
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_dVG5QPT4INkOP20mCtf3YSDM"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:01:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - a41d68647d76f0a9274850f8671aeb2a
+      Openai-Processing-Ms:
+      - '211'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=aFeLc7lC9e9UFDGtgxHcxRNPEWZ3g63ONfEClYvFHrc-1701000114-0-AUJRKm0RaztsM5HWdvV5/GIkCf1yTdzDUSCfqhXIbhzF+QyylmfdAYdNKR+VHDnVTU5REID2rqQKQZUkPy5YMXI=;
+        path=/; expires=Sun, 26-Nov-23 12:31:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Q_0yblTyEAxieedjE8Wm2b7ZCn.6xoXD_VeDqlppVRw-1701000114945-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fabc4a527725-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "run_1blECdpYHFqbesLVuScD6dcK",
+          "object": "thread.run",
+          "created_at": 1701000114,
+          "assistant_id": "asst_dVG5QPT4INkOP20mCtf3YSDM",
+          "thread_id": "thread_PkpWQxrWRbk3oIgMRjsucrhG",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000714,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:01:54 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads/thread_bR60V4ambvZEHqHDXXgnmDCr/runs
+    body:
+      encoding: UTF-8
+      string: '{"assistant_id":"asst_f62h3HTHAgj8wxU1XsOsbhdD"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:03:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - e6c9ae8bc2cb8b87bca8b163ef1c2c64
+      Openai-Processing-Ms:
+      - '215'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=JgA0ZnrbEG01l0rqVBYx92TwGl1PvrzLXiKwsSrMOL0-1701000206-0-AYPefZ/+bOUSf5Lig/gotVplxhatJA6a2SWjhzNv2us8sYrnW8EyAl4E8LpgXsTJhcsGyQ8AgW9n22lvdrlKtAM=;
+        path=/; expires=Sun, 26-Nov-23 12:33:26 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=xZmhSnxp4UFtPiqH.n7Rn.NjwegHtS9WLBv.Jd77MkE-1701000206444-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fcf80e1f0656-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "run_NAjX6p4waHWOiPvmqDHscA6e",
+          "object": "thread.run",
+          "created_at": 1701000206,
+          "assistant_id": "asst_f62h3HTHAgj8wxU1XsOsbhdD",
+          "thread_id": "thread_bR60V4ambvZEHqHDXXgnmDCr",
+          "status": "queued",
+          "started_at": null,
+          "expires_at": 1701000806,
+          "cancelled_at": null,
+          "failed_at": null,
+          "completed_at": null,
+          "last_error": null,
+          "model": "gpt-4",
+          "instructions": null,
+          "tools": [],
+          "file_ids": [],
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:03:26 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/run_steps_retrieve_thread_setup.yml
+++ b/spec/fixtures/cassettes/run_steps_retrieve_thread_setup.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/threads
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Openai-Beta:
+      - assistants=v1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 26 Nov 2023 12:03:25 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      X-Request-Id:
+      - 634bb06bf83af16c708b5d447dac549c
+      Openai-Processing-Ms:
+      - '26'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=xBNML5jzgMeJoZc2u1ofHWguMOlP2B_IV45BmRAWVGM-1701000205-0-AXs/YqQO3xz5Ah+tkwRIpAwh/XN/MGjWvOAwn57scNVPeyB7hrgovCstoll5H85zKZdsR0bfBIinv8v5QTgwXZ8=;
+        path=/; expires=Sun, 26-Nov-23 12:33:25 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=hj789rSXnHqt_rICkYtXSR8VA4MHuNvJA2jmixipuCo-1701000205741-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 82c1fcf4ed9060f7-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "thread_bR60V4ambvZEHqHDXXgnmDCr",
+          "object": "thread",
+          "created_at": 1701000205,
+          "metadata": {}
+        }
+  recorded_at: Sun, 26 Nov 2023 12:03:25 GMT
+recorded_with: VCR 6.1.0

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -5,15 +5,10 @@ RSpec.describe OpenAI::Client do
       let(:stream) { false }
       let(:response) do
         OpenAI::Client.new.chat(
-          parameters: {
-            model: model,
-            messages: messages,
-            functions: functions,
-            stream: stream
-          }
+          parameters: parameters
         )
       end
-      let(:functions) { [] }
+      let(:parameters) { { model: model, messages: messages, stream: stream } }
       let(:content) { response.dig("choices", 0, "message", "content") }
       let(:cassette) { "#{model} #{'streamed' if stream} chat".downcase }
 
@@ -37,6 +32,7 @@ RSpec.describe OpenAI::Client do
               }
             ]
           end
+          let(:parameters) { { model: model, messages: messages, stream: stream, functions: functions } }
           let(:functions) do
             [
               {

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -32,7 +32,14 @@ RSpec.describe OpenAI::Client do
               }
             ]
           end
-          let(:parameters) { { model: model, messages: messages, stream: stream, functions: functions } }
+          let(:parameters) do
+            {
+              model: model,
+              messages: messages,
+              stream: stream,
+              functions: functions
+            }
+          end
           let(:functions) do
             [
               {

--- a/spec/openai/client/run_steps_spec.rb
+++ b/spec/openai/client/run_steps_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe OpenAI::Client do
 
       it "succeeds" do
         VCR.use_cassette(cassette) do
-          expect(response.dig("object")).to eq("list")
+          expect(response["object"]).to eq("list")
         end
       end
     end
@@ -54,11 +54,9 @@ RSpec.describe OpenAI::Client do
 
       it "returns the correct error" do
         VCR.use_cassette(cassette) do
-          begin
-            response
-          rescue => e
-            expect(e.response.dig(:body, 'error', 'message')).to include("No run step found")
-          end
+          response
+        rescue StandardError => e
+          expect(e.response.dig(:body, "error", "message")).to include("No run step found")
         end
       end
     end

--- a/spec/openai/client/run_steps_spec.rb
+++ b/spec/openai/client/run_steps_spec.rb
@@ -1,17 +1,43 @@
 RSpec.describe OpenAI::Client do
   describe "#run_steps" do
+    let(:thread_id) do
+      VCR.use_cassette("#{cassette} thread setup") do
+        OpenAI::Client.new.threads.create(parameters: {})["id"]
+      end
+    end
+    let(:assistant_id) do
+      VCR.use_cassette("#{cassette} assistant setup") do
+        OpenAI::Client.new.assistants.create(
+          parameters: {
+            model: "gpt-4",
+            name: "OpenAI-Ruby test assistant"
+          }
+        )["id"]
+      end
+    end
+    let(:run_id) do
+      VCR.use_cassette("#{cassette} run setup") do
+        OpenAI::Client.new.runs.create(
+          thread_id: thread_id,
+          parameters: {
+            assistant_id: assistant_id
+          }
+        )["id"]
+      end
+    end
+
     describe "#list" do
       let(:cassette) { "run_steps list" }
       let(:response) do
         OpenAI::Client.new.run_steps.list(
-          thread_id: "thread_vd1d6cmJiUkTigpDbCMKBwry",
-          run_id: "run_kINaLRxQg4uZItMP0ExgGwAl"
+          thread_id: thread_id,
+          run_id: run_id
         )
       end
 
       it "succeeds" do
         VCR.use_cassette(cassette) do
-          expect(response.dig("data", 0, "object")).to eq("thread.run.step")
+          expect(response.dig("object")).to eq("list")
         end
       end
     end
@@ -20,15 +46,19 @@ RSpec.describe OpenAI::Client do
       let(:cassette) { "run_steps retrieve" }
       let(:response) do
         OpenAI::Client.new.run_steps.retrieve(
-          thread_id: "thread_vd1d6cmJiUkTigpDbCMKBwry",
-          run_id: "run_kINaLRxQg4uZItMP0ExgGwAl",
-          id: "step_BM4yN3TSI1mm2dbAwHUD0ATS"
+          thread_id: thread_id,
+          run_id: run_id,
+          id: "123"
         )
       end
 
-      it "succeeds" do
+      it "returns the correct error" do
         VCR.use_cassette(cassette) do
-          expect(response["object"]).to eq("thread.run.step")
+          begin
+            response
+          rescue => e
+            expect(e.response.dig(:body, 'error', 'message')).to include("No run step found")
+          end
         end
       end
     end


### PR DESCRIPTION
- Update chat_spec to not pass empty functions array, which API no longer accepts
- Fix run_steps_spec
- Add default error logging middleware
- Bump to 6.3

![Screenshot 2023-11-26 at 18 13 43](https://github.com/alexrudall/ruby-openai/assets/7175262/3a30c807-c6d4-42cf-9120-3b1b3c4e79b6)

