### PR TITLE
Files for assistants can now be PDFs,... as we only validate .jsonl files

### DIFF
--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -9,7 +9,7 @@ module OpenAI
     end
 
     def upload(parameters: {})
-      validate(file: parameters[:file])
+      validate(file: parameters[:file]) if parameters[:file].include?(".jsonl")
 
       @client.multipart_post(
         path: "/files",


### PR DESCRIPTION
Currently all files are validated on upload so it is impossible to use PDFs for assistants
This small fix now allows other types

