### PR TITLE
Call user proc when stream is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ puts response.dig("choices", 0, "message", "content")
 
 [Quick guide to streaming Chat with Rails 7 and Hotwire](https://gist.github.com/alexrudall/cb5ee1e109353ef358adb4e66631799d)
 
-You can stream from the API in realtime, which can be much faster and used to create a more engaging user experience. Pass a [Proc](https://ruby-doc.org/core-2.6/Proc.html) (or any object with a `#call` method) to the `stream` parameter to receive the stream of completion chunks as they are generated. Each time one or more chunks is received, the proc will be called once with each chunk, parsed as a Hash. The hash will be empty when the stream is [terminated](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream). If OpenAI returns an error, `ruby-openai` will raise a Faraday error.
+You can stream from the API in realtime, which can be much faster and used to create a more engaging user experience. Pass a [Proc](https://ruby-doc.org/core-2.6/Proc.html) (or any object with a `#call` method) to the `stream` parameter to receive the stream of completion chunks as they are generated. Each time one or more chunks is received, the proc will be called once with each chunk, parsed as a Hash. The Hash will be empty when the stream is [terminated](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream). If OpenAI returns an error, `ruby-openai` will raise a Faraday error.
 
 ```ruby
 client.chat(
@@ -198,9 +198,10 @@ client.chat(
         temperature: 0.7,
         stream: proc do |chunk, _bytesize|
             print chunk.dig("choices", 0, "delta", "content")
+            print "Done" if chunk == {} # Stream has been terminated
         end
     })
-# => "Anna is a young woman in her mid-twenties, with wavy chestnut hair that falls to her shoulders..."
+# => "Anna is a young woman in her mid-twenties, with wavy chestnut hair that falls to her shoulders...Done"
 ```
 
 Note: OpenAPI currently does not report token usage for streaming responses. To count tokens while streaming, try `OpenAI.rough_token_count` or [tiktoken_ruby](https://github.com/IAPark/tiktoken_ruby). We think that each call to the stream proc corresponds to a single token, so you can also try counting the number of calls to the proc to get the completion token count.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ puts response.dig("choices", 0, "message", "content")
 
 [Quick guide to streaming Chat with Rails 7 and Hotwire](https://gist.github.com/alexrudall/cb5ee1e109353ef358adb4e66631799d)
 
-You can stream from the API in realtime, which can be much faster and used to create a more engaging user experience. Pass a [Proc](https://ruby-doc.org/core-2.6/Proc.html) (or any object with a `#call` method) to the `stream` parameter to receive the stream of completion chunks as they are generated. Each time one or more chunks is received, the proc will be called once with each chunk, parsed as a Hash. If OpenAI returns an error, `ruby-openai` will raise a Faraday error.
+You can stream from the API in realtime, which can be much faster and used to create a more engaging user experience. Pass a [Proc](https://ruby-doc.org/core-2.6/Proc.html) (or any object with a `#call` method) to the `stream` parameter to receive the stream of completion chunks as they are generated. Each time one or more chunks is received, the proc will be called once with each chunk, parsed as a Hash. The hash will be empty when the stream is [terminated](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stream). If OpenAI returns an error, `ruby-openai` will raise a Faraday error.
 
 ```ruby
 client.chat(

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -65,10 +65,15 @@ module OpenAI
         end
 
         parser.feed(chunk) do |_type, data|
-          parsed_data = data == '[DONE]' ? {} : JSON.parse(data)
-          user_proc.call(parsed_data)
+          user_proc.call(parse_stream_data(data: data))
         end
       end
+    end
+
+    def parse_stream_data(data:)
+      return {} if data == "[DONE]"
+
+      JSON.parse(data)
     end
 
     def conn(multipart: false)

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -65,7 +65,8 @@ module OpenAI
         end
 
         parser.feed(chunk) do |_type, data|
-          user_proc.call(JSON.parse(data)) unless data == "[DONE]"
+          parsed_data = data == '[DONE]' ? {} : JSON.parse(data)
+          user_proc.call(parsed_data)
         end
       end
     end

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -144,6 +144,7 @@ RSpec.describe OpenAI::HTTP do
         it "calls the user proc for each data parsed as JSON" do
           expect(user_proc).to receive(:call).with(JSON.parse('{"foo": "bar"}'))
           expect(user_proc).to receive(:call).with(JSON.parse('{"baz": "qud"}'))
+          expect(user_proc).to receive(:call).with({})
 
           stream.call(<<~CHUNK)
             data: { "foo": "bar" }


### PR DESCRIPTION
## Description
This PR sends an empty Hash to the provided user proc when the final termination message is received from the OpenAI API. 

## Why?

My use-case for this is cleanup at the end of the stream, specifically flushing a buffer. For example:

```ruby
def stream_proc
  buffer = ''
  buffer_size = 10
  proc do |chunk|
    chunk_content = chunk.dig("choices", 0, "delta", "content")
    buffer += chunk_content if chunk_content
    flush = buffer.length >= buffer_size

    # Currently no way to flush the buffer on stream termination so some data might still be in the buffer.
    # With this PR, something like the following is possible:
    # flush = buffer.length >= buffer_size || chunk == {}
    if flush
      # Do the thing with buffer
      buffer = ''
    end
  end
end
```

I am interested to hear folks' thoughts on this problem and my particular solution. I'm a little ambivalent about the latter because it is a breaking change for those that expect the current behavior, but I tried a couple different ways to avoid that and it got messy.
* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
