### PR TITLE
Update Readme dotenv link

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ client = OpenAI::Client.new(access_token: "access_token_goes_here")
 
 ### With Config
 
-For a more robust setup, you can configure the gem with your API keys, for example in an `openai.rb` initializer file. Never hardcode secrets into your codebase - instead use something like [dotenv](https://github.com/motdotla/dotenv) to pass the keys safely into your environments.
+For a more robust setup, you can configure the gem with your API keys, for example in an `openai.rb` initializer file. Never hardcode secrets into your codebase - instead use something like [dotenv](https://github.com/bkeepers/dotenv) to pass the keys safely into your environments.
 
 ```ruby
 OpenAI.configure do |config|


### PR DESCRIPTION
A very minor change :) I thought it was odd that the Readme was referencing a js module for `dotenv` instead of a ruby gem.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
