### PR TITLE
add documentation that shows how to update a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,7 +712,7 @@ new_messages.each { |msg|
 }
 ```
 
-You can also update metadata on messages, including messages that come from the assistant.
+You can also update the metadata on messages, including messages that come from the assistant.
 
 ```ruby
 metadata = {

--- a/README.md
+++ b/README.md
@@ -712,6 +712,15 @@ new_messages.each { |msg|
 }
 ```
 
+You can also update metadata on messages, including messages that come from the assistant.
+
+```ruby
+metadata = {
+  user_id: "abc123"
+}
+message = client.messages.modify(id: message_id, thread_id: thread_id, parameters: { metadata: metadata })
+```
+
 At any time you can list all runs which have been performed on a particular thread or are currently running:
 
 ```ruby


### PR DESCRIPTION
This change adds a small update to the README file that documents how to use the `messages.modify` method to update the metadata for an assistant run's message. 

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
