### PR TITLE
Update fine tune README section for completion deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,16 +432,16 @@ response = client.finetunes.retrieve(id: fine_tune_id)
 fine_tuned_model = response["fine_tuned_model"]
 ```
 
-This fine-tuned model name can then be used in completions:
+This fine-tuned model name can then be used in chat completions:
 
 ```ruby
-response = client.completions(
+response = client.chat(
     parameters: {
         model: fine_tuned_model,
-        prompt: "I love Mondays!"
+        messages: [{ role: "user", content: "I love Mondays!"}]
     }
 )
-response.dig("choices", 0, "text")
+response.dig("choices", 0, "message", "content")
 ```
 
 You can also capture the events for a job:


### PR DESCRIPTION
`client.completions` is deprecated, but was still used in the example section for using fine tuned models. This just updates the readme to use `client.chat` and the appropriate param and response attributes.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
