### PR TITLE
Add  DALL·E 3 functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Stream text with GPT-4, transcribe and translate audio with Whisper, or create i
   - [Runs involving function tools](#runs-involving-function-tools)
 - [Image Generation](#image-generation)
   - [DALL·E 2](#dalle-2)
-  - [DALL·E 2](#dalle-3)
+  - [DALL·E 3](#dalle-3)
 - [Image Edit](#image-edit)
 - [Image Variations](#image-variations)
 - [Moderations](#moderations)

--- a/README.md
+++ b/README.md
@@ -726,12 +726,12 @@ puts response.dig("data", 0, "url")
 For DALL·E 3 the size of any generated images must be one of `1024x1024`, `1024x1792` or `1792x1024`. Additionally the quality of the image can be specified to either `standard` or `hd`.
 
 ```ruby
-response = client.images.generate(parameters: { prompt: "A spaniel cooking pasta wearing a hat of some sort", size: "1024x1792", quality: "standard" })
+response = client.images.generate(parameters: { prompt: "A springer spaniel cooking pasta wearing a hat of some sort", size: "1024x1792", quality: "standard" })
 puts response.dig("data", 0, "url")
 # => "https://oaidalleapiprodscus.blob.core.windows.net/private/org-Rf437IxKhh..."
 ```
 
-![Ruby](https://i.ibb.co/6y4HJFx/img-d-Tx-Rf-RHj-SO5-Gho-Cbd8o-LJvw3.png)
+![Ruby](https://i.ibb.co/z2tCKv9/img-Goio0l-S0i81-NUNa-BIx-Eh-CT6-L.png)
 
 
 ### Image Edit

--- a/README.md
+++ b/README.md
@@ -705,8 +705,11 @@ Note that you have 10 minutes to submit your tool output before the run expires.
 
 ### Image Generation
 
-Generate an image using DALL·E! The size of any generated images must be one of `256x256`, `512x512` or `1024x1024` -
-if not specified the image will default to `1024x1024`.
+Generate images using DALL·E 2 or DALL·E 3! 
+
+#### DALL·E 2
+
+For DALL·E 2 the size of any generated images must be one of `256x256`, `512x512` or `1024x1024` - if not specified the image will default to `1024x1024`.
 
 ```ruby
 response = client.images.generate(parameters: { prompt: "A baby sea otter cooking pasta wearing a hat of some sort", size: "256x256" })
@@ -715,6 +718,19 @@ puts response.dig("data", 0, "url")
 ```
 
 ![Ruby](https://i.ibb.co/6y4HJFx/img-d-Tx-Rf-RHj-SO5-Gho-Cbd8o-LJvw3.png)
+
+#### DALL·E 3
+
+For DALL·E 3 the size of any generated images must be one of `1024x1024`, `1024x1792` or `1792x1024`. Additionally the quality of the image can be specified to either `standard` or `hd`.
+
+```ruby
+response = client.images.generate(parameters: { prompt: "A spaniel cooking pasta wearing a hat of some sort", size: "1024x1792", quality: "standard" })
+puts response.dig("data", 0, "url")
+# => "https://oaidalleapiprodscus.blob.core.windows.net/private/org-Rf437IxKhh..."
+```
+
+![Ruby](https://i.ibb.co/6y4HJFx/img-d-Tx-Rf-RHj-SO5-Gho-Cbd8o-LJvw3.png)
+
 
 ### Image Edit
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Stream text with GPT-4, transcribe and translate audio with Whisper, or create i
 - [Runs](#runs)
   - [Runs involving function tools](#runs-involving-function-tools)
 - [Image Generation](#image-generation)
+  - [DALL·E 2](#dalle-2)
+  - [DALL·E 2](#dalle-3)
 - [Image Edit](#image-edit)
 - [Image Variations](#image-variations)
 - [Moderations](#moderations)

--- a/spec/fixtures/cassettes/images_edit_image_png_A_solid_red_Ruby_on_a_blue_background.yml
+++ b/spec/fixtures/cassettes/images_edit_image_png_A_solid_red_Ruby_on_a_blue_background.yml
@@ -128,8 +128,8 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTk2ZTMyNzU5Mzk5
-        Y2ZiODI0ZGFkNTUzOGNmNWZhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU3MzU4MzEyNDVhOGYz
+        NGFkNDU3M2IwZDU1MmNjMzA5DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
         LWRhdGE7IG5hbWU9ImltYWdlIjsgZmlsZW5hbWU9ImltYWdlLnBuZyINCkNv
         bnRlbnQtTGVuZ3RoOiAyNDkNCkNvbnRlbnQtVHlwZTogDQpDb250ZW50LVRy
         YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KiVBORw0KGgoAAAANSUhEUgAA
@@ -138,8 +138,8 @@ http_interactions:
         SDgNrYR+c+09uP7BQ0gICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEk
         hISQEBJCQkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEkhISQEBJC
         QkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAiJA8NoA2dv2YpOAAAAAElF
-        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYzVlOTZl
-        MzI3NTkzOTljZmI4MjRkYWQ1NTM4Y2Y1ZmENCkNvbnRlbnQtRGlzcG9zaXRp
+        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNTczNTgz
+        MTI0NWE4ZjM0YWQ0NTczYjBkNTUyY2MzMDkNCkNvbnRlbnQtRGlzcG9zaXRp
         b246IGZvcm0tZGF0YTsgbmFtZT0ibWFzayI7IGZpbGVuYW1lPSJtYXNrLnBu
         ZyINCkNvbnRlbnQtTGVuZ3RoOiAxMDkxDQpDb250ZW50LVR5cGU6IA0KQ29u
         dGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNColQTkcNChoKAAAA
@@ -167,20 +167,20 @@ http_interactions:
         elm9LzPPoBPr/ab3RhVfkMm8+VkK41jzuqRvUpvYkv47d2wx8uJhY4qPcYZv
         5tYgvVCJHqklhpTpP0MQcXy+eSd8k1ELmS6QC/XgW5m39xlxi6Trz43ueW83
         k+w4W0FKQH23G6AWJEAtSIBakAC1IAH+ABDJUOtTPUybAAAAAElFTkSuQmCC
-        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYzVlOTZlMzI3NTkz
-        OTljZmI4MjRkYWQ1NTM4Y2Y1ZmENCkNvbnRlbnQtRGlzcG9zaXRpb246IGZv
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNTczNTgzMTI0NWE4
+        ZjM0YWQ0NTczYjBkNTUyY2MzMDkNCkNvbnRlbnQtRGlzcG9zaXRpb246IGZv
         cm0tZGF0YTsgbmFtZT0icHJvbXB0Ig0KDQpBIHNvbGlkIHJlZCBSdWJ5IG9u
         IGEgYmx1ZSBiYWNrZ3JvdW5kDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFy
-        dFBvc3QtYzVlOTZlMzI3NTkzOTljZmI4MjRkYWQ1NTM4Y2Y1ZmENCkNvbnRl
+        dFBvc3QtNTczNTgzMTI0NWE4ZjM0YWQ0NTczYjBkNTUyY2MzMDkNCkNvbnRl
         bnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0ic2l6ZSINCg0KMjU2
-        eDI1Ng0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTk2ZTMy
-        NzU5Mzk5Y2ZiODI0ZGFkNTUzOGNmNWZhDQpDb250ZW50LURpc3Bvc2l0aW9u
+        eDI1Ng0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU3MzU4MzEy
+        NDVhOGYzNGFkNDU3M2IwZDU1MmNjMzA5DQpDb250ZW50LURpc3Bvc2l0aW9u
         OiBmb3JtLWRhdGE7IG5hbWU9Im1vZGVsIg0KDQpkYWxsLWUtMg0KLS0tLS0t
-        LS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTk2ZTMyNzU5Mzk5Y2ZiODI0
-        ZGFkNTUzOGNmNWZhLS0NCg==
+        LS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU3MzU4MzEyNDVhOGYzNGFkNDU3
+        M2IwZDU1MmNjMzA5LS0NCg==
     headers:
       Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-c5e96e32759399cfb824dad5538cf5fa
+      - multipart/form-data; boundary=-----------RubyMultipartPost-5735831245a8f34ad4573b0d552cc309
       Authorization:
       - Bearer <OPENAI_ACCESS_TOKEN>
       Content-Length:
@@ -197,7 +197,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 19 Jan 2024 10:56:54 GMT
+      - Fri, 19 Jan 2024 11:41:02 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -209,9 +209,9 @@ http_interactions:
       Openai-Organization:
       - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - c00cc077c6a478788811878e8c5ff336
+      - f84f42c615ba90551bf9daf2b1dc0dd4
       Openai-Processing-Ms:
-      - '8624'
+      - '8595'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -219,32 +219,32 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=nHR7rhSGspU1TcVTeDhpoRDgoH0U3LZV4a2oD0LGiXM-1705661814-1-AV7Cs8GGRd3svw9cVNQ+oo7f2tyCQwuxNOHGOL3MZAYUCLOYUY7yNJEEpX9L9pgI38UQscqJ5pmgHc97MuS7/MA=;
-        path=/; expires=Fri, 19-Jan-24 11:26:54 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=.JK71v232dWVYtlcAWeV74Ywj.gDqiJq.mjfnKnvsDE-1705664462-1-AamW9X/X1dw2XBdkcFkPnu/eABeipi3SFo1Dva9aernEMjcKsfzFpqnEiFz012TQ/PibGY0NP1Km58/jcPNcZOw=;
+        path=/; expires=Fri, 19-Jan-24 12:11:02 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=H.EHjmul0uaUnBVZNG150q2stfjo8GaIkn0KAoVEXGk-1705661814983-0-604800000;
+      - _cfuvid=sZd6n8B.XUiRfGwB50gtmFpNKqYw.5LIiR1NpYjn9Fw-1705664462443-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 847e8d90dc55360d-MAN
+      - 847ece33aec42202-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        ewogICJjcmVhdGVkIjogMTcwNTY2MTgxNCwKICAiZGF0YSI6IFsKICAgIHsK
+        ewogICJjcmVhdGVkIjogMTcwNTY2NDQ2MiwKICAiZGF0YSI6IFsKICAgIHsK
         ICAgICAgInVybCI6ICJodHRwczovL29haWRhbGxlYXBpcHJvZHNjdXMuYmxv
         Yi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLXlVZk5pZTM0ajJjQTNJ
         ckF3ZHlKcGZkYi91c2VyLTNDbHJqZGx6dG1mek1Lc3hGU1lPSUFPdS9pbWct
-        Vjh6TjRTTWoweDBMeUp6emRQb3JPcmVBLnBuZz9zdD0yMDI0LTAxLTE5VDA5
-        JTNBNTYlM0E1NFomc2U9MjAyNC0wMS0xOVQxMSUzQTU2JTNBNTRaJnNwPXIm
+        bm5YVmNYeGYyTkh5ektCVFJ6cDlpRzJ3LnBuZz9zdD0yMDI0LTAxLTE5VDEw
+        JTNBNDElM0EwMlomc2U9MjAyNC0wMS0xOVQxMiUzQTQxJTNBMDJaJnNwPXIm
         c3Y9MjAyMS0wOC0wNiZzcj1iJnJzY2Q9aW5saW5lJnJzY3Q9aW1hZ2UvcG5n
         JnNrb2lkPTZhYWFkZWRlLTRmYjMtNDY5OC1hOGY2LTY4NGQ3Nzg2YjA2NyZz
         a3RpZD1hNDhjY2E1Ni1lNmRhLTQ4NGUtYTgxNC05Yzg0OTY1MmJjYjMmc2t0
-        PTIwMjQtMDEtMThUMTYlM0ExOCUzQTMwWiZza2U9MjAyNC0wMS0xOVQxNiUz
-        QTE4JTNBMzBaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1OMWhWMHlBZ25p
-        Smk5RU1wa2I1VnolMkJ4TGpQR2VrbFRjbjhXWjhKZ3JTdVUlM0QiCiAgICB9
+        PTIwMjQtMDEtMThUMTYlM0E0MiUzQTQxWiZza2U9MjAyNC0wMS0xOVQxNiUz
+        QTQyJTNBNDFaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1Pelk3UFNGOFBH
+        SXVJL05uZWVEeVViJTJCd21mT0J2cUR0NHBxbElNbnVMcXclM0QiCiAgICB9
         CiAgXQp9Cg==
-  recorded_at: Fri, 19 Jan 2024 10:56:54 GMT
+  recorded_at: Fri, 19 Jan 2024 11:41:02 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_edit_image_png_A_solid_red_Ruby_on_a_blue_background.yml
+++ b/spec/fixtures/cassettes/images_edit_image_png_A_solid_red_Ruby_on_a_blue_background.yml
@@ -122,4 +122,129 @@ http_interactions:
         MkJscXp4eWZaSzFXS0J3Rmt2VVEwYVlFUjl4QVZCOWdKWVUlM0QiCiAgICB9
         CiAgXQp9Cg==
   recorded_at: Tue, 14 Nov 2023 21:49:13 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/images/edits
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTk2ZTMyNzU5Mzk5
+        Y2ZiODI0ZGFkNTUzOGNmNWZhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImltYWdlIjsgZmlsZW5hbWU9ImltYWdlLnBuZyINCkNv
+        bnRlbnQtTGVuZ3RoOiAyNDkNCkNvbnRlbnQtVHlwZTogDQpDb250ZW50LVRy
+        YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KiVBORw0KGgoAAAANSUhEUgAA
+        AEQAAABECAYAAAA4E5OyAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IA
+        rs4c6QAAAARnQU1BAACxjwv8YQUAAACOSURBVHgB7dBBDcAgAAAxNnGYRCz8
+        SDgNrYR+c+09uP7BQ0gICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEk
+        hISQEBJCQkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEkhISQEBJC
+        QkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAiJA8NoA2dv2YpOAAAAAElF
+        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYzVlOTZl
+        MzI3NTkzOTljZmI4MjRkYWQ1NTM4Y2Y1ZmENCkNvbnRlbnQtRGlzcG9zaXRp
+        b246IGZvcm0tZGF0YTsgbmFtZT0ibWFzayI7IGZpbGVuYW1lPSJtYXNrLnBu
+        ZyINCkNvbnRlbnQtTGVuZ3RoOiAxMDkxDQpDb250ZW50LVR5cGU6IA0KQ29u
+        dGVudC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNColQTkcNChoKAAAA
+        DUlIRFIAAABEAAAARAgGAAAAOBOTsgAAAAlwSFlzAAALEwAACxMBAJqcGAAA
+        AAFzUkdCAK7OHOkAAAAEZ0FNQQAAsY8L/GEFAAAD2ElEQVR4Ae2cTVITQRTH
+        /29CLHXFEfAEhhMYFgR25AimCqxyBZ4gcAJhZUmoit4ANwq4IJ4AOIE5AhsR
+        DZn2vRAsnarp6e75nprfJlVMU9X58/p99RuoM1AKNX/xUPMftSABakEC1IIE
+        qAUJUAsSYAHZck2EYyhcKcLYa+DyMf/suEfXDwu6Q7X4Y4KlBmGR84EWr3tB
+        /uxzCRlAGeQh8mUP2BRHJ1s0giOrh6rleXgJHxtpipOaIGwJI1LYiyNCGJ0j
+        1SVgm3feRsKkIcglW8ObNIQIsj5Qbd79MEmLSVKQa/6r7Z1u0T4yhr/DLn/0
+        kQCJRBkSB7mA5TzEEM62aNe7wzM+omPEJL4gCsdPGlg+6dEYOXLymsa/mliW
+        /SAGsY4MW8bB6SbtoGCsHql9tpZtOOBsIUUVQ/jK+2JHewAH3ARhsyyqGA+I
+        KC7Hx1oQcaBPm+ihBPzmfdo6WntBGlj5N9UuMiPeJ02xgvts2QhbQfbyjia2
+        SPSR/Mh0vbEgclQk3qOEzPOjS5O15oKocviNMKScMFwXjRRqWdQmaSL756Mz
+        ilpnJAgvcorpRcPEl0QKIr7jyybFSoeLwtzKtRHHxEI+oVporT1SkIaPD6gQ
+        XoQf0Qoix+XzKzIKV2Uh6tjoLcTHFapJqBvQC0LRYaqMkCZJ0x8Zw+yubMgV
+        SNgzrSCeQimKOFu8iaOFPGrG71EWkdvHjk61LGW+LSPN96rvdgPUggTQCiIX
+        z6ggbc330gpyC1RSkOYk/OpTn4dM0UIFkVGLsGdaQXyVzUxG1sjcSdizqNT9
+        OSqIDOGEPdMKwpecXVQR39VC2KnKDAYqhEwigRydquAj+SmdXJGxLO3jaJxu
+        0YsK+djQPTcRpDLHRmbTEDF+ZZS6q4TGlfLGZGbEVJB22a1kNqBn4A+Nizt2
+        rm9RYjjJHJqss6l2W2vvVaGHZMLoDFQfhqObVuW/8tBfH6ollIj1d7P97pqu
+        t+2HLPpTnJelLSD79Bs4t/kd+wYRF3w/J2bnMW9uZJ+WU85OHTMujrprA1Vo
+        J9uR/ZF9LebcQuQQtlNUUTr3+3IKALFn3UkmmZvoFaFDLz5jfkycq/TYTWY5
+        PjdTXOQdfSSasBgXccQQkum6s6P17/B9Fu9zYO1QbfsLMzGWEJPk35eRNyMU
+        elm9LzPPoBPr/ab3RhVfkMm8+VkK41jzuqRvUpvYkv47d2wx8uJhY4qPcYZv
+        5tYgvVCJHqklhpTpP0MQcXy+eSd8k1ELmS6QC/XgW5m39xlxi6Trz43ueW83
+        k+w4W0FKQH23G6AWJEAtSIBakAC1IAH+ABDJUOtTPUybAAAAAElFTkSuQmCC
+        DQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYzVlOTZlMzI3NTkz
+        OTljZmI4MjRkYWQ1NTM4Y2Y1ZmENCkNvbnRlbnQtRGlzcG9zaXRpb246IGZv
+        cm0tZGF0YTsgbmFtZT0icHJvbXB0Ig0KDQpBIHNvbGlkIHJlZCBSdWJ5IG9u
+        IGEgYmx1ZSBiYWNrZ3JvdW5kDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFy
+        dFBvc3QtYzVlOTZlMzI3NTkzOTljZmI4MjRkYWQ1NTM4Y2Y1ZmENCkNvbnRl
+        bnQtRGlzcG9zaXRpb246IGZvcm0tZGF0YTsgbmFtZT0ic2l6ZSINCg0KMjU2
+        eDI1Ng0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTk2ZTMy
+        NzU5Mzk5Y2ZiODI0ZGFkNTUzOGNmNWZhDQpDb250ZW50LURpc3Bvc2l0aW9u
+        OiBmb3JtLWRhdGE7IG5hbWU9Im1vZGVsIg0KDQpkYWxsLWUtMg0KLS0tLS0t
+        LS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWM1ZTk2ZTMyNzU5Mzk5Y2ZiODI0
+        ZGFkNTUzOGNmNWZhLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-c5e96e32759399cfb824dad5538cf5fa
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Content-Length:
+      - '2221'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Jan 2024 10:56:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-3clrjdlztmfzmksxfsyoiaou
+      X-Request-Id:
+      - c00cc077c6a478788811878e8c5ff336
+      Openai-Processing-Ms:
+      - '8624'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=nHR7rhSGspU1TcVTeDhpoRDgoH0U3LZV4a2oD0LGiXM-1705661814-1-AV7Cs8GGRd3svw9cVNQ+oo7f2tyCQwuxNOHGOL3MZAYUCLOYUY7yNJEEpX9L9pgI38UQscqJ5pmgHc97MuS7/MA=;
+        path=/; expires=Fri, 19-Jan-24 11:26:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=H.EHjmul0uaUnBVZNG150q2stfjo8GaIkn0KAoVEXGk-1705661814983-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 847e8d90dc55360d-MAN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        ewogICJjcmVhdGVkIjogMTcwNTY2MTgxNCwKICAiZGF0YSI6IFsKICAgIHsK
+        ICAgICAgInVybCI6ICJodHRwczovL29haWRhbGxlYXBpcHJvZHNjdXMuYmxv
+        Yi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLXlVZk5pZTM0ajJjQTNJ
+        ckF3ZHlKcGZkYi91c2VyLTNDbHJqZGx6dG1mek1Lc3hGU1lPSUFPdS9pbWct
+        Vjh6TjRTTWoweDBMeUp6emRQb3JPcmVBLnBuZz9zdD0yMDI0LTAxLTE5VDA5
+        JTNBNTYlM0E1NFomc2U9MjAyNC0wMS0xOVQxMSUzQTU2JTNBNTRaJnNwPXIm
+        c3Y9MjAyMS0wOC0wNiZzcj1iJnJzY2Q9aW5saW5lJnJzY3Q9aW1hZ2UvcG5n
+        JnNrb2lkPTZhYWFkZWRlLTRmYjMtNDY5OC1hOGY2LTY4NGQ3Nzg2YjA2NyZz
+        a3RpZD1hNDhjY2E1Ni1lNmRhLTQ4NGUtYTgxNC05Yzg0OTY1MmJjYjMmc2t0
+        PTIwMjQtMDEtMThUMTYlM0ExOCUzQTMwWiZza2U9MjAyNC0wMS0xOVQxNiUz
+        QTE4JTNBMzBaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1OMWhWMHlBZ25p
+        Smk5RU1wa2I1VnolMkJ4TGpQR2VrbFRjbjhXWjhKZ3JTdVUlM0QiCiAgICB9
+        CiAgXQp9Cg==
+  recorded_at: Fri, 19 Jan 2024 10:56:54 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_generate_A_baby_sea_otter_cooking_pasta_wearing_a_hat_of_some_sort.yml
+++ b/spec/fixtures/cassettes/images_generate_A_baby_sea_otter_cooking_pasta_wearing_a_hat_of_some_sort.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.openai.com/v1/images/generations
     body:
       encoding: UTF-8
-      string: '{"prompt":"A baby sea otter cooking pasta wearing a hat of some sort","size":"256x256"}'
+      string: '{"prompt":"A baby sea otter cooking pasta wearing a hat of some sort","size":"256x256","model":"dall-e-2"}'
     headers:
       Content-Type:
       - application/json
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:49:05 GMT
+      - Fri, 19 Jan 2024 10:56:44 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -33,11 +33,11 @@ http_interactions:
       Openai-Version:
       - '2020-10-01'
       Openai-Organization:
-      - user-jxm65ijkzc1qrfhc0ij8moic
+      - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - da2a8e023b3850d1963e74d15ea61265
+      - 86b88d9ff37ce4c1b619bfe68a053ac4
       Openai-Processing-Ms:
-      - '6793'
+      - '6622'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -45,27 +45,27 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=l8voAfjBmXkOVIzgl4o8njq.2O7pe8yiw.BRlQGzpJw-1699998545-0-Ad1XI+yQvIGADy+QVylNynfWFCBXG5+p3DOYyU6g95OU9tAbbFB8/vSbcmrdjQNG60e0wHbltmL/keeCeo3EOKQ=;
-        path=/; expires=Tue, 14-Nov-23 22:19:05 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=wEx.D4yoyDlIamJuRHDX7t3Iy2xuKSID7gcx5oQYH_U-1705661804-1-AcXvhW9vr/0kmRsXfYLKZ08e225ESpjgCQwaNVltTonFLCCR1VbkWvZlDK8PA3h1zjdeaJ2XWuuWGGqozYboSJw=;
+        path=/; expires=Fri, 19-Jan-24 11:26:44 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=gJPRUdTYYGlJO6V1X5vjcaCrDRZvoo_t43a91aLRwEo-1699998545009-0-604800000;
+      - _cfuvid=pbNnl.ZFFdlZ.F6RKawMY12cxXvALOoPMBg5koRTL1Q-1705661804986-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 8262762f0ecc4141-LHR
+      - 847e8d5ee8e76aab-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "created": 1699998544,
+          "created": 1705661804,
           "data": [
             {
-              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-Rf437IxKhhQPMiIQ0Es8OwrH/user-jxM65ijkZc1qRfHC0IJ8mOIc/img-74iavMuNGu1zboQISmi16Vc0.png?st=2023-11-14T20%3A49%3A04Z&se=2023-11-14T22%3A49%3A04Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2023-11-14T16%3A57%3A40Z&ske=2023-11-15T16%3A57%3A40Z&sks=b&skv=2021-08-06&sig=OSVXGW6mRn9WQeQE2oAm/wULPMzsiZZMw/vHuVQ0nBQ%3D"
+              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-7GZpu1NzukAdVUWonuhKR3w5.png?st=2024-01-19T09%3A56%3A44Z&se=2024-01-19T11%3A56%3A44Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T17%3A18%3A07Z&ske=2024-01-19T17%3A18%3A07Z&sks=b&skv=2021-08-06&sig=mCIggFyAoF1rwjJIvNJ%2BYoQzH1fzXwEf5JZ4WfBlwfU%3D"
             }
           ]
         }
-  recorded_at: Tue, 14 Nov 2023 21:49:05 GMT
+  recorded_at: Fri, 19 Jan 2024 10:56:44 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_generate_A_baby_sea_otter_cooking_pasta_wearing_a_hat_of_some_sort.yml
+++ b/spec/fixtures/cassettes/images_generate_A_baby_sea_otter_cooking_pasta_wearing_a_hat_of_some_sort.yml
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 19 Jan 2024 10:56:44 GMT
+      - Fri, 19 Jan 2024 11:40:53 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,9 +35,9 @@ http_interactions:
       Openai-Organization:
       - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - 86b88d9ff37ce4c1b619bfe68a053ac4
+      - 0137f54d99d1362b1e623d676116a4c9
       Openai-Processing-Ms:
-      - '6622'
+      - '6822'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -45,27 +45,27 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=wEx.D4yoyDlIamJuRHDX7t3Iy2xuKSID7gcx5oQYH_U-1705661804-1-AcXvhW9vr/0kmRsXfYLKZ08e225ESpjgCQwaNVltTonFLCCR1VbkWvZlDK8PA3h1zjdeaJ2XWuuWGGqozYboSJw=;
-        path=/; expires=Fri, 19-Jan-24 11:26:44 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=P36Wd_cn8juahMszhsJOx5kkOYVokwSxjGZmiTuOep8-1705664453-1-AWK8XEV35FFAXSMl+MBEJ2XPKC3KQc4hWuMvbTkdXErcByHJJo77vuiKXigfEXUDZKpOT8VxsAaRxiyE/ZV9wbE=;
+        path=/; expires=Fri, 19-Jan-24 12:10:53 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=pbNnl.ZFFdlZ.F6RKawMY12cxXvALOoPMBg5koRTL1Q-1705661804986-0-604800000;
+      - _cfuvid=BoKuzauoIz4K9oDwnJtEGtFjVAkD0lnYqLBXdB4lehc-1705664453478-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 847e8d5ee8e76aab-MAN
+      - 847ece06be0a0755-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "created": 1705661804,
+          "created": 1705664453,
           "data": [
             {
-              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-7GZpu1NzukAdVUWonuhKR3w5.png?st=2024-01-19T09%3A56%3A44Z&se=2024-01-19T11%3A56%3A44Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T17%3A18%3A07Z&ske=2024-01-19T17%3A18%3A07Z&sks=b&skv=2021-08-06&sig=mCIggFyAoF1rwjJIvNJ%2BYoQzH1fzXwEf5JZ4WfBlwfU%3D"
+              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-TXGcLfiIhAqPEEED1eQ4SyMg.png?st=2024-01-19T10%3A40%3A53Z&se=2024-01-19T12%3A40%3A53Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T22%3A51%3A44Z&ske=2024-01-19T22%3A51%3A44Z&sks=b&skv=2021-08-06&sig=AFx2RqTU0Zb2Klk3QPFO06JtipjPmGadWbVVOVQkVeU%3D"
             }
           ]
         }
-  recorded_at: Fri, 19 Jan 2024 10:56:44 GMT
+  recorded_at: Fri, 19 Jan 2024 11:40:53 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_generate_A_lion_cooking_pasta_wearing_a_hat_of_some_sort.yml
+++ b/spec/fixtures/cassettes/images_generate_A_lion_cooking_pasta_wearing_a_hat_of_some_sort.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://api.openai.com/v1/images/generations
     body:
       encoding: UTF-8
-      string: '{"prompt":"A lion cooking pasta wearing a hat of some sort","size":"1024x1792","model":"dall-e-3","quality":"hd"}'
+      string: '{"prompt":"A lion cooking pasta wearing a hat of some sort","size":"1024x1792","model":"dall-e-3"}'
     headers:
       Content-Type:
       - application/json
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 19 Jan 2024 10:57:37 GMT
+      - Fri, 19 Jan 2024 11:41:21 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -35,9 +35,9 @@ http_interactions:
       Openai-Organization:
       - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - fe907b9489e7d83f0ee5487803d84de6
+      - 5c602879c1c1d3c21b0faf3c8f1e417c
       Openai-Processing-Ms:
-      - '18721'
+      - '11625'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -45,28 +45,28 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=dky10DT3zM8QKLgzK2mHkmYovCtA_f5ajxO_H_xlHdo-1705661857-1-AdjemWtc+rfH0jZnFilOpv8vhCVI1Q0UWDKo6Piuq7hcqSOqb2Ljbw9K/MWPO0Z3fcE51bMq2z3tmngJyav+SGs=;
-        path=/; expires=Fri, 19-Jan-24 11:27:37 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=6DhyV5lYuSUqSaP7r3ndJlF9hodvtjR15fiMeK_IMGk-1705664481-1-AaNCm7swyfR8AXQ1X8Sn4C1vbpMqWrktIawC837YM6bDYGt8mE7sSBq4jwoQY3Xh7ECMdeb/rjs89/Z+dr6cgE4=;
+        path=/; expires=Fri, 19-Jan-24 12:11:21 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=acyy7yMbvNIeosUdp.I8NjwucsxX0JlooXaWXLC7vd8-1705661857796-0-604800000;
+      - _cfuvid=tETtXfFrcHhBNZcH5pZKFutvyt8ij_eev9lXQBKZFEg-1705664481896-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 847e8e5d28f90ac1-MAN
+      - 847ece99cb572218-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "created": 1705661857,
+          "created": 1705664481,
           "data": [
             {
-              "revised_prompt": "A visually stunning image of a majestic lion standing inside a cozy kitchen. The lion, absorbed in his work, is carefully preparing a large pot of pasta. On his head, he wears a unique and whimsical hat, which adds a fun and lighthearted element to the scene. The room is filled with the warm, inviting aroma of the pasta and the cozy tones of the kitchen surroundings. The gentle lighting throws soft shadows that enhance the texture and detail of the lion's golden fur.",
-              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-yxaQdEs2eLxnYDouXYH8qq98.png?st=2024-01-19T09%3A57%3A37Z&se=2024-01-19T11%3A57%3A37Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T14%3A35%3A38Z&ske=2024-01-19T14%3A35%3A38Z&sks=b&skv=2021-08-06&sig=5khTdWBUB8dUJEfZ34IKawagP%2BEpAxY8FC8mXtdf3BM%3D"
+              "revised_prompt": "Imagine a scene where a majestic African lion is at the kitchen counter, showing its culinary skills by cooking pasta. It is wearing a hat, perhaps a chef's toque blanche, signifying its enthusiasm for the cooking task. The beast's huge paws are adroitly handling a large wooden spoon, stirring the pasta in a pot. The cooking station is set up with usual kitchen tools, including a stove, saucepans, and jars of herbs and spices. It's a humorous juxtaposition of wild savannah royalty mastering Italian cuisine.",
+              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-lPntzOJceaEP5Yw2qDqylhcI.png?st=2024-01-19T10%3A41%3A21Z&se=2024-01-19T12%3A41%3A21Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T16%3A48%3A54Z&ske=2024-01-19T16%3A48%3A54Z&sks=b&skv=2021-08-06&sig=ZkWonoooyYqC5qVhaKwDKOyni6UCZ%2BFL4Rq54mstq4c%3D"
             }
           ]
         }
-  recorded_at: Fri, 19 Jan 2024 10:57:37 GMT
+  recorded_at: Fri, 19 Jan 2024 11:41:21 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_generate_A_lion_cooking_pasta_wearing_a_hat_of_some_sort.yml
+++ b/spec/fixtures/cassettes/images_generate_A_lion_cooking_pasta_wearing_a_hat_of_some_sort.yml
@@ -1,0 +1,73 @@
+---
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/images/generations
+    body:
+      encoding: UTF-8
+      string: '{"prompt":"A lion cooking pasta wearing a hat of some sort","size":"1024x1792","model":"dall-e-3","quality":"hd"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 12 Jan 2024 19:20:54 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-3clrjdlztmfzmksxfsyoiaou
+      X-Request-Id:
+      - 69aaedef446d998c94d68fafd607da8c
+      Openai-Processing-Ms:
+      - '24085'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=LG6QLy.8enzl_uL7TiteJ3XnVeI7Fw0qoB.R_C5p3mY-1705087254-1-AcswiAj+uloT+6w6C2zsUxltqUsg1P0lJhPoAT9aunUkTUBxwksXSRts2Upyr504+LhAsOs2zoDIGXAuaYiXIFc=;
+        path=/; expires=Fri, 12-Jan-24 19:50:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=jkCBOf6JV3y0pc_FnifYoHg3kueZX1rsk8nf6SwMg8g-1705087254150-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8447c1d2fdb4360d-MAN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "created": 1705087254,
+          "data": [
+            {
+              "revised_prompt": "A full-grown male lion, with his golden mane, intense eyes, and stately pose, is found in an unexpected scenario. He is in a brightly lit kitchen, standing near a cooktop. A large pot of boiling pasta is on the stove, steam rising from it. With one paw, he is deftly stirring the pasta, exhibiting a careful touch. He's wearing a red and white checkered chef's hat on his head. Despite his wild nature, he seems completely at ease, creating a surprising but unique image.",
+              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-H8Ae3VfCrtX9xszbJMBooz6u.png?st=2024-01-12T18%3A20%3A54Z&se=2024-01-12T20%3A20%3A54Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-12T16%3A51%3A42Z&ske=2024-01-13T16%3A51%3A42Z&sks=b&skv=2021-08-06&sig=XOxfI6omNpOBF4i4HgDaXQvZGPn%2Bs1atX1PPRIj2QiY%3D"
+            }
+          ]
+        }
+  recorded_at: Fri, 12 Jan 2024 19:20:54 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_generate_A_lion_cooking_pasta_wearing_a_hat_of_some_sort.yml
+++ b/spec/fixtures/cassettes/images_generate_A_lion_cooking_pasta_wearing_a_hat_of_some_sort.yml
@@ -1,5 +1,4 @@
 ---
----
 http_interactions:
 - request:
     method: post
@@ -24,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 12 Jan 2024 19:20:54 GMT
+      - Fri, 19 Jan 2024 10:57:37 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -36,9 +35,9 @@ http_interactions:
       Openai-Organization:
       - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - 69aaedef446d998c94d68fafd607da8c
+      - fe907b9489e7d83f0ee5487803d84de6
       Openai-Processing-Ms:
-      - '24085'
+      - '18721'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -46,28 +45,28 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=LG6QLy.8enzl_uL7TiteJ3XnVeI7Fw0qoB.R_C5p3mY-1705087254-1-AcswiAj+uloT+6w6C2zsUxltqUsg1P0lJhPoAT9aunUkTUBxwksXSRts2Upyr504+LhAsOs2zoDIGXAuaYiXIFc=;
-        path=/; expires=Fri, 12-Jan-24 19:50:54 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=dky10DT3zM8QKLgzK2mHkmYovCtA_f5ajxO_H_xlHdo-1705661857-1-AdjemWtc+rfH0jZnFilOpv8vhCVI1Q0UWDKo6Piuq7hcqSOqb2Ljbw9K/MWPO0Z3fcE51bMq2z3tmngJyav+SGs=;
+        path=/; expires=Fri, 19-Jan-24 11:27:37 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=jkCBOf6JV3y0pc_FnifYoHg3kueZX1rsk8nf6SwMg8g-1705087254150-0-604800000;
+      - _cfuvid=acyy7yMbvNIeosUdp.I8NjwucsxX0JlooXaWXLC7vd8-1705661857796-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 8447c1d2fdb4360d-MAN
+      - 847e8e5d28f90ac1-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "created": 1705087254,
+          "created": 1705661857,
           "data": [
             {
-              "revised_prompt": "A full-grown male lion, with his golden mane, intense eyes, and stately pose, is found in an unexpected scenario. He is in a brightly lit kitchen, standing near a cooktop. A large pot of boiling pasta is on the stove, steam rising from it. With one paw, he is deftly stirring the pasta, exhibiting a careful touch. He's wearing a red and white checkered chef's hat on his head. Despite his wild nature, he seems completely at ease, creating a surprising but unique image.",
-              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-H8Ae3VfCrtX9xszbJMBooz6u.png?st=2024-01-12T18%3A20%3A54Z&se=2024-01-12T20%3A20%3A54Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-12T16%3A51%3A42Z&ske=2024-01-13T16%3A51%3A42Z&sks=b&skv=2021-08-06&sig=XOxfI6omNpOBF4i4HgDaXQvZGPn%2Bs1atX1PPRIj2QiY%3D"
+              "revised_prompt": "A visually stunning image of a majestic lion standing inside a cozy kitchen. The lion, absorbed in his work, is carefully preparing a large pot of pasta. On his head, he wears a unique and whimsical hat, which adds a fun and lighthearted element to the scene. The room is filled with the warm, inviting aroma of the pasta and the cozy tones of the kitchen surroundings. The gentle lighting throws soft shadows that enhance the texture and detail of the lion's golden fur.",
+              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-yxaQdEs2eLxnYDouXYH8qq98.png?st=2024-01-19T09%3A57%3A37Z&se=2024-01-19T11%3A57%3A37Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T14%3A35%3A38Z&ske=2024-01-19T14%3A35%3A38Z&sks=b&skv=2021-08-06&sig=5khTdWBUB8dUJEfZ34IKawagP%2BEpAxY8FC8mXtdf3BM%3D"
             }
           ]
         }
-  recorded_at: Fri, 12 Jan 2024 19:20:54 GMT
+  recorded_at: Fri, 19 Jan 2024 10:57:37 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_generate_A_springer_spaniel_cooking_pasta_wearing_a_hat_of_some_sort.yml
+++ b/spec/fixtures/cassettes/images_generate_A_springer_spaniel_cooking_pasta_wearing_a_hat_of_some_sort.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/images/generations
+    body:
+      encoding: UTF-8
+      string: '{"prompt":"A springer spaniel cooking pasta wearing a hat of some sort","size":"1024x1792","model":"dall-e-3","quality":"hd"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 19 Jan 2024 11:41:43 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-3clrjdlztmfzmksxfsyoiaou
+      X-Request-Id:
+      - 841b96c7c3e59de019ca442e5a5fd952
+      Openai-Processing-Ms:
+      - '21223'
+      Access-Control-Allow-Origin:
+      - "*"
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=3UWJ2o4PsE.3GO8keMie.8V4pYciys6GwDed_VxnWJs-1705664503-1-AZIZVBfFXLqTHjOpGtj74TRLZyZZG+gWXkjVPF3QVrmAEwogEG0mhkUFbn8TdunFcI7lALYQVopwePkvz63u9vg=;
+        path=/; expires=Fri, 19-Jan-24 12:11:43 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=p7znYjVqwOf1GbVBfYNSd7M6bFYHy1bC0lPsFZGVcUA-1705664503377-0-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 847ecee48fc70756-MAN
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "created": 1705664503,
+          "data": [
+            {
+              "revised_prompt": "A Springer Spaniel, a breed of medium-sized dog known for its happy-go-lucky personality and long ears, is standing on its hind legs undeniably excited about preparing a delicious pasta meal. The pooch is wearing a comical, oversized chef's hat that's tilting to the side due to its weight and making the whole scene quite amusing. There are ingredients like tomatoes, olives, and basil scattered around hinting at a possible recipe for marinara pasta. The mischievous grin on the pet's face promises some shenanigans in the kitchen.",
+              "url": "https://oaidalleapiprodscus.blob.core.windows.net/private/org-yUfNie34j2cA3IrAwdyJpfdb/user-3ClrjdlztmfzMKsxFSYOIAOu/img-cmjF40NV4CA8oW8sFimbaDtt.png?st=2024-01-19T10%3A41%3A43Z&se=2024-01-19T12%3A41%3A43Z&sp=r&sv=2021-08-06&sr=b&rscd=inline&rsct=image/png&skoid=6aaadede-4fb3-4698-a8f6-684d7786b067&sktid=a48cca56-e6da-484e-a814-9c849652bcb3&skt=2024-01-18T22%3A17%3A03Z&ske=2024-01-19T22%3A17%3A03Z&sks=b&skv=2021-08-06&sig=jLf8Wk1RayKzcHpT5rNiuBNmaD3ZtU0ZNC5J4psyS/U%3D"
+            }
+          ]
+        }
+  recorded_at: Fri, 19 Jan 2024 11:41:43 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_variations_image_png.yml
+++ b/spec/fixtures/cassettes/images_variations_image_png.yml
@@ -6,8 +6,8 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWMyYjk0YTkxMzNjYTgz
-        ZmJjMDJiYzFhYjZkZThjYmJmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWEwN2RhZDE0NTE4NDY1
+        OTUxMGIwOTBjNGRiODI3MTk3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
         LWRhdGE7IG5hbWU9ImltYWdlIjsgZmlsZW5hbWU9ImltYWdlLnBuZyINCkNv
         bnRlbnQtTGVuZ3RoOiAyNDkNCkNvbnRlbnQtVHlwZTogDQpDb250ZW50LVRy
         YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KiVBORw0KGgoAAAANSUhEUgAA
@@ -16,16 +16,16 @@ http_interactions:
         SDgNrYR+c+09uP7BQ0gICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEk
         hISQEBJCQkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEkhISQEBJC
         QkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAiJA8NoA2dv2YpOAAAAAElF
-        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYzJiOTRh
-        OTEzM2NhODNmYmMwMmJjMWFiNmRlOGNiYmYNCkNvbnRlbnQtRGlzcG9zaXRp
+        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYTA3ZGFk
+        MTQ1MTg0NjU5NTEwYjA5MGM0ZGI4MjcxOTcNCkNvbnRlbnQtRGlzcG9zaXRp
         b246IGZvcm0tZGF0YTsgbmFtZT0ibiINCg0KMg0KLS0tLS0tLS0tLS0tLVJ1
-        YnlNdWx0aXBhcnRQb3N0LWMyYjk0YTkxMzNjYTgzZmJjMDJiYzFhYjZkZThj
-        YmJmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InNp
+        YnlNdWx0aXBhcnRQb3N0LWEwN2RhZDE0NTE4NDY1OTUxMGIwOTBjNGRiODI3
+        MTk3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InNp
         emUiDQoNCjI1NngyNTYNCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9z
-        dC1jMmI5NGE5MTMzY2E4M2ZiYzAyYmMxYWI2ZGU4Y2JiZi0tDQo=
+        dC1hMDdkYWQxNDUxODQ2NTk1MTBiMDkwYzRkYjgyNzE5Ny0tDQo=
     headers:
       Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-c2b94a9133ca83fbc02bc1ab6de8cbbf
+      - multipart/form-data; boundary=-----------RubyMultipartPost-a07dad145184659510b090c4db827197
       Authorization:
       - Bearer <OPENAI_ACCESS_TOKEN>
       Content-Length:
@@ -42,7 +42,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Tue, 14 Nov 2023 21:49:21 GMT
+      - Fri, 19 Jan 2024 10:57:03 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -52,11 +52,11 @@ http_interactions:
       Openai-Version:
       - '2020-10-01'
       Openai-Organization:
-      - user-jxm65ijkzc1qrfhc0ij8moic
+      - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - 802c4069532872a0bb0ea38afedae6f9
+      - 45ce77fcc206074d87017da5d3c71adb
       Openai-Processing-Ms:
-      - '7999'
+      - '7336'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -64,43 +64,43 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=5PRyY33BoQkWab.1mwOsCD6czwjG7eFBOkJl8aMWf4g-1699998561-0-Aa17f9am74jS/Fmz3DAcs5fGVxtbejOHwkTc0aIf9G+Gczt3nzjRtnEH0pdOEGwgxFIgxrfgN2eahlsfiYBvG8o=;
-        path=/; expires=Tue, 14-Nov-23 22:19:21 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=dQbmZlO22bjXaXwP581MaJI61M69Pz9uOe2KbTB.HOM-1705661823-1-Ae+Xqyi8pqZmbaE9rVCEs0YE50IQ3GvEq20p6XTmc1238LsmfFhk+Xl8vEL8r7flviy6AqqOulHJFzEj9NHwu+w=;
+        path=/; expires=Fri, 19-Jan-24 11:27:03 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=TA45wF3oD6xvfipDFiABzwIIblR1jBDogrPlvJwj6ek-1699998561894-0-604800000;
+      - _cfuvid=LO7hiKYEpopo_VSYONEbkWAkAuax.RjQuLvLR0mwIxs-1705661823011-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 82627690ea4260f9-LHR
+      - 847e8dc9d9583607-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        ewogICJjcmVhdGVkIjogMTY5OTk5ODU2MSwKICAiZGF0YSI6IFsKICAgIHsK
+        ewogICJjcmVhdGVkIjogMTcwNTY2MTgyMiwKICAiZGF0YSI6IFsKICAgIHsK
         ICAgICAgInVybCI6ICJodHRwczovL29haWRhbGxlYXBpcHJvZHNjdXMuYmxv
-        Yi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLVJmNDM3SXhLaGhRUE1p
-        SVEwRXM4T3dySC91c2VyLWp4TTY1aWprWmMxcVJmSEMwSUo4bU9JYy9pbWct
-        ZnNMOUJYcHpIa2xRS09HeEUwQmNXdnhFLnBuZz9zdD0yMDIzLTExLTE0VDIw
-        JTNBNDklM0EyMVomc2U9MjAyMy0xMS0xNFQyMiUzQTQ5JTNBMjFaJnNwPXIm
+        Yi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLXlVZk5pZTM0ajJjQTNJ
+        ckF3ZHlKcGZkYi91c2VyLTNDbHJqZGx6dG1mek1Lc3hGU1lPSUFPdS9pbWct
+        Tlgxb2Q2MjBPYXF3a2U2SnlHTUVpWWY5LnBuZz9zdD0yMDI0LTAxLTE5VDA5
+        JTNBNTclM0EwMlomc2U9MjAyNC0wMS0xOVQxMSUzQTU3JTNBMDJaJnNwPXIm
         c3Y9MjAyMS0wOC0wNiZzcj1iJnJzY2Q9aW5saW5lJnJzY3Q9aW1hZ2UvcG5n
         JnNrb2lkPTZhYWFkZWRlLTRmYjMtNDY5OC1hOGY2LTY4NGQ3Nzg2YjA2NyZz
         a3RpZD1hNDhjY2E1Ni1lNmRhLTQ4NGUtYTgxNC05Yzg0OTY1MmJjYjMmc2t0
-        PTIwMjMtMTEtMTRUMTclM0E0NyUzQTE2WiZza2U9MjAyMy0xMS0xNVQxNyUz
-        QTQ3JTNBMTZaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz0xYkxod2pQNnRx
-        SjRFbE1hYUw5SmlwajdlN1NJcUhRbXVzbUw0Skw1Nm5JJTNEIgogICAgfSwK
+        PTIwMjQtMDEtMThUMjMlM0E1MyUzQTQ2WiZza2U9MjAyNC0wMS0xOVQyMyUz
+        QTUzJTNBNDZaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1mWTRQdEM4WlJv
+        bkg1V3FXMjRaaWJwMnVLOHBWT0Mwa2xFSU9NM2FsWkFFJTNEIgogICAgfSwK
         ICAgIHsKICAgICAgInVybCI6ICJodHRwczovL29haWRhbGxlYXBpcHJvZHNj
-        dXMuYmxvYi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLVJmNDM3SXhL
-        aGhRUE1pSVEwRXM4T3dySC91c2VyLWp4TTY1aWprWmMxcVJmSEMwSUo4bU9J
-        Yy9pbWctdThmb2xJTHJCVG9CWkNmNVhZY25KSFdwLnBuZz9zdD0yMDIzLTEx
-        LTE0VDIwJTNBNDklM0EyMVomc2U9MjAyMy0xMS0xNFQyMiUzQTQ5JTNBMjFa
+        dXMuYmxvYi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLXlVZk5pZTM0
+        ajJjQTNJckF3ZHlKcGZkYi91c2VyLTNDbHJqZGx6dG1mek1Lc3hGU1lPSUFP
+        dS9pbWctdjFTOUlCSDZGc3E1YU10R0E4ZEptRFUzLnBuZz9zdD0yMDI0LTAx
+        LTE5VDA5JTNBNTclM0EwMlomc2U9MjAyNC0wMS0xOVQxMSUzQTU3JTNBMDJa
         JnNwPXImc3Y9MjAyMS0wOC0wNiZzcj1iJnJzY2Q9aW5saW5lJnJzY3Q9aW1h
         Z2UvcG5nJnNrb2lkPTZhYWFkZWRlLTRmYjMtNDY5OC1hOGY2LTY4NGQ3Nzg2
         YjA2NyZza3RpZD1hNDhjY2E1Ni1lNmRhLTQ4NGUtYTgxNC05Yzg0OTY1MmJj
-        YjMmc2t0PTIwMjMtMTEtMTRUMTclM0E0NyUzQTE2WiZza2U9MjAyMy0xMS0x
-        NVQxNyUzQTQ3JTNBMTZaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1tVGJ2
-        ZyUyQldKZ2ZzVDRBbnJjblBmMmhZOXdEVlpPVWVXdUlOJTJCOGR5ZGhWMCUz
-        RCIKICAgIH0KICBdCn0K
-  recorded_at: Tue, 14 Nov 2023 21:49:21 GMT
+        YjMmc2t0PTIwMjQtMDEtMThUMjMlM0E1MyUzQTQ2WiZza2U9MjAyNC0wMS0x
+        OVQyMyUzQTUzJTNBNDZaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1pbEF3
+        eUdua2ZtQTlEWkhnNEcvbkVDeUcyVXV5NWlIVDdCc21HUVlxZDN3JTNEIgog
+        ICAgfQogIF0KfQo=
+  recorded_at: Fri, 19 Jan 2024 10:57:03 GMT
 recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/images_variations_image_png.yml
+++ b/spec/fixtures/cassettes/images_variations_image_png.yml
@@ -6,8 +6,8 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWEwN2RhZDE0NTE4NDY1
-        OTUxMGIwOTBjNGRiODI3MTk3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTcxNDQzNjM2ZDI2Y2Rj
+        ZGYwYWY3OWQzMTdlNDYzZWZiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
         LWRhdGE7IG5hbWU9ImltYWdlIjsgZmlsZW5hbWU9ImltYWdlLnBuZyINCkNv
         bnRlbnQtTGVuZ3RoOiAyNDkNCkNvbnRlbnQtVHlwZTogDQpDb250ZW50LVRy
         YW5zZmVyLUVuY29kaW5nOiBiaW5hcnkNCg0KiVBORw0KGgoAAAANSUhEUgAA
@@ -16,16 +16,16 @@ http_interactions:
         SDgNrYR+c+09uP7BQ0gICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEk
         hISQEBJCQkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAgJISEkhISQEBJC
         QkgICSEhJISEkBASQkJICAkhISSEhJAQEkJCSAiJA8NoA2dv2YpOAAAAAElF
-        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYTA3ZGFk
-        MTQ1MTg0NjU5NTEwYjA5MGM0ZGI4MjcxOTcNCkNvbnRlbnQtRGlzcG9zaXRp
+        TkSuQmCCDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNzE0NDM2
+        MzZkMjZjZGNkZjBhZjc5ZDMxN2U0NjNlZmINCkNvbnRlbnQtRGlzcG9zaXRp
         b246IGZvcm0tZGF0YTsgbmFtZT0ibiINCg0KMg0KLS0tLS0tLS0tLS0tLVJ1
-        YnlNdWx0aXBhcnRQb3N0LWEwN2RhZDE0NTE4NDY1OTUxMGIwOTBjNGRiODI3
-        MTk3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InNp
+        YnlNdWx0aXBhcnRQb3N0LTcxNDQzNjM2ZDI2Y2RjZGYwYWY3OWQzMTdlNDYz
+        ZWZiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3JtLWRhdGE7IG5hbWU9InNp
         emUiDQoNCjI1NngyNTYNCi0tLS0tLS0tLS0tLS1SdWJ5TXVsdGlwYXJ0UG9z
-        dC1hMDdkYWQxNDUxODQ2NTk1MTBiMDkwYzRkYjgyNzE5Ny0tDQo=
+        dC03MTQ0MzYzNmQyNmNkY2RmMGFmNzlkMzE3ZTQ2M2VmYi0tDQo=
     headers:
       Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-a07dad145184659510b090c4db827197
+      - multipart/form-data; boundary=-----------RubyMultipartPost-71443636d26cdcdf0af79d317e463efb
       Authorization:
       - Bearer <OPENAI_ACCESS_TOKEN>
       Content-Length:
@@ -42,7 +42,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 19 Jan 2024 10:57:03 GMT
+      - Fri, 19 Jan 2024 11:41:09 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -54,9 +54,9 @@ http_interactions:
       Openai-Organization:
       - user-3clrjdlztmfzmksxfsyoiaou
       X-Request-Id:
-      - 45ce77fcc206074d87017da5d3c71adb
+      - 1cca6fb71b6a1bf15a4127f734a8b9e6
       Openai-Processing-Ms:
-      - '7336'
+      - '7105'
       Access-Control-Allow-Origin:
       - "*"
       Strict-Transport-Security:
@@ -64,43 +64,43 @@ http_interactions:
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
-      - __cf_bm=dQbmZlO22bjXaXwP581MaJI61M69Pz9uOe2KbTB.HOM-1705661823-1-Ae+Xqyi8pqZmbaE9rVCEs0YE50IQ3GvEq20p6XTmc1238LsmfFhk+Xl8vEL8r7flviy6AqqOulHJFzEj9NHwu+w=;
-        path=/; expires=Fri, 19-Jan-24 11:27:03 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=kFwzE5lN.P1OKEQy8iFZ44b9tvdsVfwArs9C8bwqGEU-1705664469-1-Ae/zxATqzb5YTorbVEyVNfjzlSy8RgjV03CB27e859yKeK5OsjrEzo9inGlE1R3b/a4dp96FDgrArw0lIEH9dnk=;
+        path=/; expires=Fri, 19-Jan-24 12:11:09 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=LO7hiKYEpopo_VSYONEbkWAkAuax.RjQuLvLR0mwIxs-1705661823011-0-604800000;
+      - _cfuvid=hRvpSNS5c8._NCgJYKs1_r4R8BMl0Mh_qqxPa0REN.E-1705664469838-0-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Server:
       - cloudflare
       Cf-Ray:
-      - 847e8dc9d9583607-MAN
+      - 847ece6adcdc54bd-MAN
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       base64_string: |
-        ewogICJjcmVhdGVkIjogMTcwNTY2MTgyMiwKICAiZGF0YSI6IFsKICAgIHsK
+        ewogICJjcmVhdGVkIjogMTcwNTY2NDQ2OSwKICAiZGF0YSI6IFsKICAgIHsK
         ICAgICAgInVybCI6ICJodHRwczovL29haWRhbGxlYXBpcHJvZHNjdXMuYmxv
         Yi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLXlVZk5pZTM0ajJjQTNJ
         ckF3ZHlKcGZkYi91c2VyLTNDbHJqZGx6dG1mek1Lc3hGU1lPSUFPdS9pbWct
-        Tlgxb2Q2MjBPYXF3a2U2SnlHTUVpWWY5LnBuZz9zdD0yMDI0LTAxLTE5VDA5
-        JTNBNTclM0EwMlomc2U9MjAyNC0wMS0xOVQxMSUzQTU3JTNBMDJaJnNwPXIm
+        SURqYU9OVUlVWDIxVWtVWE8xZU1qYjF3LnBuZz9zdD0yMDI0LTAxLTE5VDEw
+        JTNBNDElM0EwOVomc2U9MjAyNC0wMS0xOVQxMiUzQTQxJTNBMDlaJnNwPXIm
         c3Y9MjAyMS0wOC0wNiZzcj1iJnJzY2Q9aW5saW5lJnJzY3Q9aW1hZ2UvcG5n
         JnNrb2lkPTZhYWFkZWRlLTRmYjMtNDY5OC1hOGY2LTY4NGQ3Nzg2YjA2NyZz
         a3RpZD1hNDhjY2E1Ni1lNmRhLTQ4NGUtYTgxNC05Yzg0OTY1MmJjYjMmc2t0
-        PTIwMjQtMDEtMThUMjMlM0E1MyUzQTQ2WiZza2U9MjAyNC0wMS0xOVQyMyUz
-        QTUzJTNBNDZaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1mWTRQdEM4WlJv
-        bkg1V3FXMjRaaWJwMnVLOHBWT0Mwa2xFSU9NM2FsWkFFJTNEIgogICAgfSwK
-        ICAgIHsKICAgICAgInVybCI6ICJodHRwczovL29haWRhbGxlYXBpcHJvZHNj
-        dXMuYmxvYi5jb3JlLndpbmRvd3MubmV0L3ByaXZhdGUvb3JnLXlVZk5pZTM0
-        ajJjQTNJckF3ZHlKcGZkYi91c2VyLTNDbHJqZGx6dG1mek1Lc3hGU1lPSUFP
-        dS9pbWctdjFTOUlCSDZGc3E1YU10R0E4ZEptRFUzLnBuZz9zdD0yMDI0LTAx
-        LTE5VDA5JTNBNTclM0EwMlomc2U9MjAyNC0wMS0xOVQxMSUzQTU3JTNBMDJa
-        JnNwPXImc3Y9MjAyMS0wOC0wNiZzcj1iJnJzY2Q9aW5saW5lJnJzY3Q9aW1h
-        Z2UvcG5nJnNrb2lkPTZhYWFkZWRlLTRmYjMtNDY5OC1hOGY2LTY4NGQ3Nzg2
-        YjA2NyZza3RpZD1hNDhjY2E1Ni1lNmRhLTQ4NGUtYTgxNC05Yzg0OTY1MmJj
-        YjMmc2t0PTIwMjQtMDEtMThUMjMlM0E1MyUzQTQ2WiZza2U9MjAyNC0wMS0x
-        OVQyMyUzQTUzJTNBNDZaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz1pbEF3
-        eUdua2ZtQTlEWkhnNEcvbkVDeUcyVXV5NWlIVDdCc21HUVlxZDN3JTNEIgog
-        ICAgfQogIF0KfQo=
-  recorded_at: Fri, 19 Jan 2024 10:57:03 GMT
+        PTIwMjQtMDEtMThUMTglM0EyNCUzQTE1WiZza2U9MjAyNC0wMS0xOVQxOCUz
+        QTI0JTNBMTVaJnNrcz1iJnNrdj0yMDIxLTA4LTA2JnNpZz13L0kwRnRMaDFu
+        R2FmQ1klMkJWQ1N0MEY0WC9HeUtDd2V1aDdXQU9rM2pHakUlM0QiCiAgICB9
+        LAogICAgewogICAgICAidXJsIjogImh0dHBzOi8vb2FpZGFsbGVhcGlwcm9k
+        c2N1cy5ibG9iLmNvcmUud2luZG93cy5uZXQvcHJpdmF0ZS9vcmcteVVmTmll
+        MzRqMmNBM0lyQXdkeUpwZmRiL3VzZXItM0NscmpkbHp0bWZ6TUtzeEZTWU9J
+        QU91L2ltZy16T0I3V3JvUWh0dkNOU204UUJLcnBoOWcucG5nP3N0PTIwMjQt
+        MDEtMTlUMTAlM0E0MSUzQTA5WiZzZT0yMDI0LTAxLTE5VDEyJTNBNDElM0Ew
+        OVomc3A9ciZzdj0yMDIxLTA4LTA2JnNyPWImcnNjZD1pbmxpbmUmcnNjdD1p
+        bWFnZS9wbmcmc2tvaWQ9NmFhYWRlZGUtNGZiMy00Njk4LWE4ZjYtNjg0ZDc3
+        ODZiMDY3JnNrdGlkPWE0OGNjYTU2LWU2ZGEtNDg0ZS1hODE0LTljODQ5NjUy
+        YmNiMyZza3Q9MjAyNC0wMS0xOFQxOCUzQTI0JTNBMTVaJnNrZT0yMDI0LTAx
+        LTE5VDE4JTNBMjQlM0ExNVomc2tzPWImc2t2PTIwMjEtMDgtMDYmc2lnPXdD
+        aFd5RzBlYkY3cmNhUDd0JTJCSXV3eUN3dlVPZDlmaWtVejJDaTBBRnN1VSUz
+        RCIKICAgIH0KICBdCn0K
+  recorded_at: Fri, 19 Jan 2024 11:41:09 GMT
 recorded_with: VCR 6.1.0

--- a/spec/openai/client/images_spec.rb
+++ b/spec/openai/client/images_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe OpenAI::Client do
         end
       end
     end
-  
+
     describe "#dall-e-3" do
       describe "#generate" do
         describe "#standard", :vcr do
@@ -90,7 +90,7 @@ RSpec.describe OpenAI::Client do
           let(:prompt) { "A lion cooking pasta wearing a hat of some sort" }
           let(:size) { "1024x1792" } # using a size only available in dall-e-3
           let(:model) { "dall-e-3" }
-    
+
           it "succeeds" do
             VCR.use_cassette(cassette) do
               expect(response.dig("data", 0, "url")).to include("dalle")
@@ -114,7 +114,7 @@ RSpec.describe OpenAI::Client do
           let(:size) { "1024x1792" }
           let(:model) { "dall-e-3" }
           let(:quality) { "hd" }
-    
+
           it "succeeds" do
             VCR.use_cassette(cassette) do
               expect(response.dig("data", 0, "url")).to include("dalle")

--- a/spec/openai/client/images_spec.rb
+++ b/spec/openai/client/images_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe OpenAI::Client do
             )
           end
           let(:cassette) { "images generate #{prompt}" }
-          let(:prompt) { "A lion cooking pasta wearing a hat of some sort" }
+          let(:prompt) { "A springer spaniel cooking pasta wearing a hat of some sort" }
           let(:size) { "1024x1792" }
           let(:model) { "dall-e-3" }
           let(:quality) { "hd" }

--- a/spec/openai/client/images_spec.rb
+++ b/spec/openai/client/images_spec.rb
@@ -1,69 +1,125 @@
 RSpec.describe OpenAI::Client do
   describe "#images" do
-    describe "#generate", :vcr do
-      let(:response) do
-        OpenAI::Client.new.images.generate(
-          parameters: {
-            prompt: prompt,
-            size: size
-          }
-        )
-      end
-      let(:cassette) { "images generate #{prompt}" }
-      let(:prompt) { "A baby sea otter cooking pasta wearing a hat of some sort" }
-      let(:size) { "256x256" }
+    describe "#dall-e-2" do
+      describe "#generate", :vcr do
+        let(:response) do
+          OpenAI::Client.new.images.generate(
+            parameters: {
+              prompt: prompt,
+              size: size,
+              model: model
+            }
+          )
+        end
+        let(:cassette) { "images generate #{prompt}" }
+        let(:prompt) { "A baby sea otter cooking pasta wearing a hat of some sort" }
+        let(:size) { "256x256" }
+        let(:model) { "dall-e-2" }
 
-      it "succeeds" do
-        VCR.use_cassette(cassette) do
-          expect(response.dig("data", 0, "url")).to include("dalle")
+        it "succeeds" do
+          VCR.use_cassette(cassette) do
+            expect(response.dig("data", 0, "url")).to include("dalle")
+          end
+        end
+      end
+
+      describe "#edit", :vcr do
+        let(:response) do
+          OpenAI::Client.new.images.edit(
+            parameters: {
+              image: image,
+              mask: mask,
+              prompt: prompt,
+              size: size,
+              model: model
+            }
+          )
+        end
+        let(:cassette) { "images edit #{image_filename} #{prompt}" }
+        let(:prompt) { "A solid red Ruby on a blue background" }
+        let(:image) { File.join(RSPEC_ROOT, "fixtures/files", image_filename) }
+        let(:image_filename) { "image.png" }
+        let(:mask) { File.join(RSPEC_ROOT, "fixtures/files", mask_filename) }
+        let(:mask_filename) { "mask.png" }
+        let(:size) { "256x256" }
+        let(:model) { "dall-e-2" }
+
+        it "succeeds" do
+          VCR.use_cassette(cassette, preserve_exact_body_bytes: true) do
+            expect(response.dig("data", 0, "url")).to include("dalle")
+          end
+        end
+      end
+
+      describe "#variations", :vcr do
+        let(:response) do
+          OpenAI::Client.new.images.variations(
+            parameters: {
+              image: image,
+              n: 2,
+              size: size
+            }
+          )
+        end
+        let(:cassette) { "images variations #{image_filename}" }
+        let(:image) { File.join(RSPEC_ROOT, "fixtures/files", image_filename) }
+        let(:image_filename) { "image.png" }
+        let(:size) { "256x256" }
+
+        it "succeeds" do
+          VCR.use_cassette(cassette, preserve_exact_body_bytes: true) do
+            expect(response.dig("data", 0, "url")).to include("dalle")
+          end
         end
       end
     end
-
-    describe "#edit", :vcr do
-      let(:response) do
-        OpenAI::Client.new.images.edit(
-          parameters: {
-            image: image,
-            mask: mask,
-            prompt: prompt,
-            size: size
-          }
-        )
-      end
-      let(:cassette) { "images edit #{image_filename} #{prompt}" }
-      let(:prompt) { "A solid red Ruby on a blue background" }
-      let(:image) { File.join(RSPEC_ROOT, "fixtures/files", image_filename) }
-      let(:image_filename) { "image.png" }
-      let(:mask) { File.join(RSPEC_ROOT, "fixtures/files", mask_filename) }
-      let(:mask_filename) { "mask.png" }
-      let(:size) { "256x256" }
-
-      it "succeeds" do
-        VCR.use_cassette(cassette, preserve_exact_body_bytes: true) do
-          expect(response.dig("data", 0, "url")).to include("dalle")
+  
+    describe "#dall-e-3" do
+      describe "#generate" do
+        describe "#standard", :vcr do
+          let(:response) do
+            OpenAI::Client.new.images.generate(
+              parameters: {
+                prompt: prompt,
+                size: size,
+                model: model
+              }
+            )
+          end
+          let(:cassette) { "images generate #{prompt}" }
+          let(:prompt) { "A lion cooking pasta wearing a hat of some sort" }
+          let(:size) { "1024x1792" } # using a size only available in dall-e-3
+          let(:model) { "dall-e-3" }
+    
+          it "succeeds" do
+            VCR.use_cassette(cassette) do
+              expect(response.dig("data", 0, "url")).to include("dalle")
+            end
+          end
         end
-      end
-    end
 
-    describe "#variations", :vcr do
-      let(:response) do
-        OpenAI::Client.new.images.variations(
-          parameters: {
-            image: image,
-            n: 2,
-            size: size
-          }
-        )
-      end
-      let(:cassette) { "images variations #{image_filename}" }
-      let(:image) { File.join(RSPEC_ROOT, "fixtures/files", image_filename) }
-      let(:image_filename) { "image.png" }
-      let(:size) { "256x256" }
-
-      it "succeeds" do
-        VCR.use_cassette(cassette, preserve_exact_body_bytes: true) do
-          expect(response.dig("data", 0, "url")).to include("dalle")
+        describe "#hd", :vcr do
+          let(:response) do
+            OpenAI::Client.new.images.generate(
+              parameters: {
+                prompt: prompt,
+                size: size,
+                model: model,
+                quality: quality
+              }
+            )
+          end
+          let(:cassette) { "images generate #{prompt}" }
+          let(:prompt) { "A lion cooking pasta wearing a hat of some sort" }
+          let(:size) { "1024x1792" }
+          let(:model) { "dall-e-3" }
+          let(:quality) { "hd" }
+    
+          it "succeeds" do
+            VCR.use_cassette(cassette) do
+              expect(response.dig("data", 0, "url")).to include("dalle")
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Hello @alexrudall. I've created this PR to _make a start_ on making the DALLE 3 available in the gem. 

I think this PR has some way to go. In particular, I'm not sure how/if changes should be made to `lib/images.rb`. 

I've made an addition to the spec for images. In particular I've broken out the functionality of both DALLE2 and DALLE3. At the moment there is only the ability to generate images in DALLE3 hence the omission of edits and variations. 

I added a new tests for DALL·E 3 and my VCR recording. 

I've also made a start on updating the README.md. 

If you could let me know if this is appropriate or what else might need done I will be happy to take this as far as I can.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
