### PR TITLE
Remove inexistent threads#list API

### DIFF
--- a/lib/openai/threads.rb
+++ b/lib/openai/threads.rb
@@ -4,10 +4,6 @@ module OpenAI
       @client = client.beta(assistants: "v1")
     end
 
-    def list
-      @client.get(path: "/threads")
-    end
-
     def retrieve(id:)
       @client.get(path: "/threads/#{id}")
     end


### PR DESCRIPTION
The [Threads API](https://platform.openai.com/docs/api-reference/threads/createThread) doesn't expose a method to get the list of threads. It isn't listed on the official documentation:

<img width="209" alt="Screenshot 2024-01-21 at 10 10 17 PM" src="https://github.com/alexrudall/ruby-openai/assets/11672878/8b4f816e-7c66-4bd0-bfef-f931ba86296a">

Trying that endpoint returns the following error:
```
"OpenAI HTTP Error (spotted in ruby-openai 6.3.1): {"error"=>{"message"=>"Your request to GET /v1/threads must be made with a session key (that is, it can only be made from the browser). You made it with the following key type: secret.", "type"=>"invalid_request_error", "param"=>nil, "code"=>"missing_scope"}}"
```

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
