### PR TITLE
Update README.md - mention "language" attribute explicitely in #transcribe

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,7 @@ response = client.audio.transcribe(
     parameters: {
         model: "whisper-1",
         file: File.open("path_to_file", "rb"),
+        language: "en"
     })
 puts response["text"]
 # => "Transcription of the text"


### PR DESCRIPTION
I believe that some significant portion of `#transcribe` function might be using it in languages other than English.
For them it might be handy to clearly see that "language" attribute is (implicitly) supported so that they don't need to check `Create transcription` documentation at https://platform.openai.com/docs/api-reference/audio/createTranscription?lang=node.

[X] I checked locally that it works with explicit "en" value and a few other languages

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
