### PR TITLE
fix: update uri to omit deployment ids for assistant and thread paths

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -86,11 +86,19 @@ module OpenAI
 
     def uri(path:)
       if azure?
-        base = File.join(@uri_base, path)
-        "#{base}?api-version=#{@api_version}"
+        azure_uri(path)
       else
         File.join(@uri_base, @api_version, path)
       end
+    end
+
+    def azure_uri(path:)
+      base = File.join(@uri_base, path)
+    
+      # Remove the deployment to support assistants for azure
+      base = base.gsub(/\/deployments\/.+\//, '/') if (path.include?('/assistants') || path.include?('/threads'))
+      
+      "#{base}?api-version=#{@api_version}"
     end
 
     def multipart_parameters(parameters)

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -239,6 +239,12 @@ RSpec.describe OpenAI::HTTP do
         let(:uri_base) { "https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo" }
         it { expect(uri).to eq("https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo/chat?api-version=v1") }
       end
+
+      context "with assistants" do
+        let(:path) { "/assistants" }
+        let(:uri_base) { "https://custom-domain.openai.azure.com/openai/deployments/gpt-35-turbo" }
+        it { expect(uri).to eq("https://custom-domain.openai.azure.com/openai/assistants?api-version=v1") }
+      end
     end
   end
 


### PR DESCRIPTION
Summary:
Solves [this issue](https://github.com/alexrudall/ruby-openai/issues/430)

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
