### PR TITLE
Added /completions endpoint back to support gpt-3.5-turbo-instruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,20 @@ end
 # => "The weather is nice 🌞"
 ```
 
+### Completions
+
+Hit the OpenAI API for a completion using other GPT-3 models:
+
+````ruby
+response = client.completions(
+    parameters: {
+        model: "text-davinci-001",
+        prompt: "Once upon a time",
+        max_tokens: 5
+    })
+puts response["choices"].map { |c| c["text"] }
+# => [", there lived a great"]
+
 ### Edits
 
 Send a string and some instructions for what to do to the string:
@@ -413,7 +427,7 @@ response = client.edits(
 )
 puts response.dig("choices", 0, "text")
 # => What day of the week is it?
-```
+````
 
 ### Embeddings
 

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ response = client.edits(
 )
 puts response.dig("choices", 0, "text")
 # => What day of the week is it?
-````
+```
 
 ### Embeddings
 
@@ -882,3 +882,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the Ruby OpenAI project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/alexrudall/ruby-openai/blob/main/CODE_OF_CONDUCT.md).
+````

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ end
 
 Hit the OpenAI API for a completion using other GPT-3 models:
 
-````ruby
+```ruby
 response = client.completions(
     parameters: {
         model: "text-davinci-001",
@@ -412,6 +412,7 @@ response = client.completions(
     })
 puts response["choices"].map { |c| c["text"] }
 # => [", there lived a great"]
+```
 
 ### Edits
 
@@ -882,4 +883,3 @@ The gem is available as open source under the terms of the [MIT License](https:/
 ## Code of Conduct
 
 Everyone interacting in the Ruby OpenAI project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/alexrudall/ruby-openai/blob/main/CODE_OF_CONDUCT.md).
-````

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -34,6 +34,10 @@ module OpenAI
       json_post(path: "/embeddings", parameters: parameters)
     end
 
+    def completions(parameters: {})
+      json_post(path: "/completions", parameters: parameters)
+    end
+
     def audio
       @audio ||= OpenAI::Audio.new(client: self)
     end

--- a/spec/fixtures/cassettes/gpt-3_5-turbo-instruct_completions_once_upon_a_time.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo-instruct_completions_once_upon_a_time.yml
@@ -1,0 +1,98 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-3.5-turbo-instruct","prompt":"Once upon a time","max_tokens":5}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 31 Mar 2024 20:12:02 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Openai-Model:
+      - gpt-3.5-turbo-instruct
+      Openai-Organization:
+      - user-jxm65ijkzc1qrfhc0ij8moic
+      Openai-Processing-Ms:
+      - '363'
+      Openai-Version:
+      - '2020-10-01'
+      Strict-Transport-Security:
+      - max-age=15724800; includeSubDomains
+      X-Ratelimit-Limit-Requests:
+      - '3500'
+      X-Ratelimit-Limit-Tokens:
+      - '90000'
+      X-Ratelimit-Remaining-Requests:
+      - '3499'
+      X-Ratelimit-Remaining-Tokens:
+      - '89991'
+      X-Ratelimit-Reset-Requests:
+      - 17ms
+      X-Ratelimit-Reset-Tokens:
+      - 6ms
+      X-Request-Id:
+      - req_6a274b7a73c52b0fbf2145ca5f1e9fbf
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=ZK5b4LtJsPBMzdMnaU837z6PMPEXsKabybnXGNeAmu4-1711915922-1.0.1.1-Fzur3qermYdXljcE8Z20zrY4Z5RD.UrreUTa7MVZUOUQcflGoKGPpTAykRjfvZ7mGo9ehY_kRdp4dRPfdrteBQ;
+        path=/; expires=Sun, 31-Mar-24 20:42:02 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Gh5SFdjA.KVOM3VmAG5grUJVRLihOStH3B_jABN7Nys-1711915922569-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 86d2fdefec9a531a-LHR
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "cmpl-98vp4W2Nm6k1hJt3vzOqLVXTrhvX4",
+          "object": "text_completion",
+          "created": 1711915922,
+          "model": "gpt-3.5-turbo-instruct",
+          "choices": [
+            {
+              "text": ", there stood a wizard",
+              "index": 0,
+              "logprobs": null,
+              "finish_reason": "length"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 4,
+            "completion_tokens": 5,
+            "total_tokens": 9
+          }
+        }
+  recorded_at: Sun, 31 Mar 2024 20:12:02 GMT
+recorded_with: VCR 6.1.0

--- a/spec/openai/client/completions_spec.rb
+++ b/spec/openai/client/completions_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe OpenAI::Client do
+  describe "#completions: gpt-3.5-turbo-instruct" do
+    context "with a prompt and max_tokens", :vcr do
+      let(:prompt) { "Once upon a time" }
+      let(:max_tokens) { 5 }
+
+      let(:response) do
+        OpenAI::Client.new.completions(
+          parameters: {
+            model: model,
+            prompt: prompt,
+            max_tokens: max_tokens
+          }
+        )
+      end
+      let(:text) { response.dig("choices", 0, "text") }
+      let(:cassette) { "#{model} completions #{prompt}".downcase }
+      let(:model) { "gpt-3.5-turbo-instruct" }
+
+      it "succeeds" do
+        VCR.use_cassette(cassette) do
+          expect(text.split.empty?).to eq(false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change addresses the issue discussed [here](https://github.com/alexrudall/ruby-openai/issues/381). With the current state, it is impossible to use `gpt-3.5-turbo-instruct` without the completions endpoint or downgrading the gem version.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
