### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ puts response.dig("data", 0, "url")
 For DALL·E 3 the size of any generated images must be one of `1024x1024`, `1024x1792` or `1792x1024`. Additionally the quality of the image can be specified to either `standard` or `hd`.
 
 ```ruby
-response = client.images.generate(parameters: { prompt: "A springer spaniel cooking pasta wearing a hat of some sort", size: "1024x1792", quality: "standard" })
+response = client.images.generate(parameters: { prompt: "A springer spaniel cooking pasta wearing a hat of some sort", model: "dall-e-3", size: "1024x1792", quality: "standard" })
 puts response.dig("data", 0, "url")
 # => "https://oaidalleapiprodscus.blob.core.windows.net/private/org-Rf437IxKhh..."
 ```


### PR DESCRIPTION
Clarify that in order to use the DALL-E 3 model, images need to be generated with the correct parameters.

The current documentation suggests that it's possible to generate images with either DALL-E 2 or DALL-E 3, but it's unclear how to pick the model. This PR clarifies that the `model: "dall-e-3"` option needs to be used to get DALL-E 3 images.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
