### PR TITLE
Handle API version in base URI

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -88,6 +88,8 @@ module OpenAI
       if azure?
         base = File.join(@uri_base, path)
         "#{base}?api-version=#{@api_version}"
+      elsif @uri_base.include?(@api_version)
+        File.join(@uri_base, path)
       else
         File.join(@uri_base, @api_version, path)
       end

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -204,6 +204,18 @@ RSpec.describe OpenAI::HTTP do
 
     it { expect(uri).to eq("https://api.openai.com/v1/chat") }
 
+    context "uri_base with version included" do
+      before do
+        OpenAI.configuration.uri_base = "https://api.openai.com/v1/"
+      end
+
+      after do
+        OpenAI.configuration.uri_base = "https://api.openai.com/"
+      end
+
+      it { expect(uri).to eq("https://api.openai.com/v1/chat") }
+    end
+
     context "uri_base without trailing slash" do
       before do
         OpenAI.configuration.uri_base = "https://api.openai.com"


### PR DESCRIPTION
- Replacement for #395 - if the API version is already in the uri_base, don't add it again
- Example: [Portkey](https://portkey.ai/docs/api-reference/gateway-for-other-apis#you-can-call-the-endpoint-by-adding-it-after-https-api.portkey.ai-v1)