### PR TITLE
If being used for Groq, skip OpenAI-Organization header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
-/.bundle/
 
 # Used by dotenv library to load environment variables.
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 /.yardoc
 /_yardoc/
 /doc/
-/TAGS
 
 # Used by dotenv library to load environment variables.
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 /.yardoc
 /_yardoc/
 /doc/
-
+/TAGS
 
 # Used by dotenv library to load environment variables.
 .env

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,6 @@
 /test/version_tmp/
 /tmp/
 /.bundle/
-/.yardoc
-/_yardoc/
-/doc/
 
 # Used by dotenv library to load environment variables.
 .env

--- a/lib/openai/http_headers.rb
+++ b/lib/openai/http_headers.rb
@@ -19,7 +19,7 @@ module OpenAI
         "Content-Type" => "application/json",
         "Authorization" => "Bearer #{@access_token}",
         "OpenAI-Organization" => @organization_id
-      }
+      }.compact
     end
 
     def azure_headers

--- a/spec/openai/client/http_spec.rb
+++ b/spec/openai/client/http_spec.rb
@@ -263,7 +263,7 @@ RSpec.describe OpenAI::HTTP do
 
     it {
       expect(headers).to eq({ "Authorization" => "Bearer #{OpenAI.configuration.access_token}",
-                              "Content-Type" => "application/json", "OpenAI-Organization" => nil })
+                              "Content-Type" => "application/json" })
     }
 
     describe "with Azure" do


### PR DESCRIPTION
I've looked at using groq via langchain -> ruby-openai and was seeing a warning about me not setting `OpenAI-Organization`. If I run `.compact` on the headers, the warning seems to go away.
