### PR TITLE
Add parameters support to batches.list and update README to include /v1/embeddings Batches support

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,11 +497,9 @@ puts response.dig("data", 0, "embedding")
 ```
 
 ### Batches
-
-The Batches endpoint allows you to create and manage large batches of API requests to run asynchronously. Currently, only the `/v1/chat/completions` endpoint is supported for batches.
+The Batches endpoint allows you to create and manage large batches of API requests to run asynchronously. Currently, the supported endpoints for batches are `/v1/chat/completions` (Chat Completions API) and `/v1/embeddings` (Embeddings API).
 
 To use the Batches endpoint, you need to first upload a JSONL file containing the batch requests using the Files endpoint. The file must be uploaded with the purpose set to `batch`. Each line in the JSONL file represents a single request and should have the following format:
-
 ```json
 {
   "custom_id": "request-1",

--- a/lib/openai/batches.rb
+++ b/lib/openai/batches.rb
@@ -4,8 +4,8 @@ module OpenAI
       @client = client.beta(assistants: OpenAI::Assistants::BETA_VERSION)
     end
 
-    def list
-      @client.get(path: "/batches")
+    def list(parameters: {})
+      @client.get(path: "/batches", parameters: parameters)
     end
 
     def retrieve(id:)


### PR DESCRIPTION
Closes #490

I added a new test that creates a batch first, so we can test the `after` parameter. Without an existing batch, it would return an error.

**Edit:** Looks like there's some Rubocop linting issues. I wasn't able to get Rubocop running so perhaps @alexrudall you can take care of these as they seem auto-fixable.

**Edit 2:** Okay, I fixed the Rubocop linting issues. Only thing left to make the test pass is to record a new VCR cassette. I'm not comfortable getting my company details in there, so can you do it @alexrudall? I already checked locally, and the test pass with a valid API key.