### PR TITLE
(feat): add Faraday proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,26 @@ client = OpenAI::Client.new(access_token: "access_token_goes_here")
 client.add_headers("X-Proxy-TTL" => "43200")
 ```
 
+#### Proxy support
+
+You can use proxy with Faraday
+
+```ruby
+proxy = {
+  :uri      => 'http://proxy.example.com',
+  :user     => 'foo',
+  :password => 'bar'
+}
+
+OpenAI::Client.new(access_token: "access_token_goes_here", proxy: proxy)
+```
+
+Or use with string
+
+```ruby
+OpenAI::Client.new(access_token: "access_token_goes_here", proxy: "foo:bar@http://proxy.example.com")
+```
+
 #### Logging
 
 ##### Errors

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -47,6 +47,7 @@ module OpenAI
                   :organization_id,
                   :uri_base,
                   :request_timeout,
+                  :proxy,
                   :extra_headers
 
     DEFAULT_API_VERSION = "v1".freeze

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -63,6 +63,7 @@ module OpenAI
       @uri_base = DEFAULT_URI_BASE
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @extra_headers = {}
+      @proxy = nil
     end
   end
 

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -11,6 +11,7 @@ module OpenAI
       uri_base
       request_timeout
       extra_headers
+      proxy
     ].freeze
     attr_reader *CONFIG_KEYS, :faraday_middleware
 

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -73,6 +73,7 @@ module OpenAI
     def conn(multipart: false)
       connection = Faraday.new do |f|
         f.options[:timeout] = @request_timeout
+        f.proxy = @proxy if @proxy
         f.request(:multipart) if multipart
         f.use MiddlewareErrors if @log_errors
         f.response :raise_error


### PR DESCRIPTION
## Summary
Adding the ability to use a proxy when proxy from ENV is not suitable.

```ruby
proxy = {
  :uri      => 'http://proxy.example.com',
  :user     => 'foo',
  :password => 'bar'
}

OpenAI::Client.new(access_token: "access_token_goes_here", proxy: proxy)
```


## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
