### PR TITLE
fix fetching binary files such as images

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -41,7 +41,8 @@ module OpenAI
 
     def parse_jsonl(response)
       return unless response
-      return response unless response.is_a?(String)
+
+      return response unless response.is_a?(String) && response.is_utf8?
 
       # Convert a multiline string of JSON objects to a JSON array.
       response = response.gsub("}\n{", "},{").prepend("[").concat("]")


### PR DESCRIPTION
Hello, when I fetch binary files such as images create by code_interpreter, I get a parsing error.

I determined that this is because response.is_a?(String) returns true for binary files such as png.

This PR fixes the parsing error, but I suspect there may be a better way to fix it. 

For example, if someone was using non-utf-8 string encoding, this could break. 

May need more investigation?

## All Submissions:

* [*] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [*] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [*] Have you added an explanation of what your changes do and why you'd like us to include them?
