### PR TITLE
Update README.md with Velvet config link

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ client = OpenAI::Client.new(access_token: "access_token_goes_here")
 
 #### Custom timeout or base URI
 
-The default timeout for any request using this library is 120 seconds. You can change that by passing a number of seconds to the `request_timeout` when initializing the client. You can also change the base URI used for all requests, eg. to use observability tools like [Helicone](https://docs.helicone.ai/quickstart/integrate-in-one-line-of-code), and add arbitrary other headers e.g. for [openai-caching-proxy-worker](https://github.com/6/openai-caching-proxy-worker):
+The default timeout for any request using this library is 120 seconds. You can change that by passing a number of seconds to the `request_timeout` when initializing the client. You can also change the base URI used for all requests, eg. to use observability tools like [Helicone](https://docs.helicone.ai/quickstart/integrate-in-one-line-of-code) or [Velvet](https://docs.usevelvet.com/docs/getting-started), and add arbitrary other headers e.g. for [openai-caching-proxy-worker](https://github.com/6/openai-caching-proxy-worker):
 
 ```ruby
 client = OpenAI::Client.new(


### PR DESCRIPTION
We're using Velvet instead of Helicone on our rails app ([usefind.ai](https://usefind.ai)), so I wanted to update the docs to reference that. Setup is pretty much the same as helicone.

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
