### PR TITLE
Hide sensitive info when inspecting client

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -2,6 +2,7 @@ module OpenAI
   class Client
     include OpenAI::HTTP
 
+    SENSITIVE_ATTRIBUTES = %i[@access_token @organization_id @extra_headers].freeze
     CONFIG_KEYS = %i[
       api_type
       api_version
@@ -109,12 +110,10 @@ module OpenAI
     end
 
     def inspect
-      sensitive_attributes = %i[@access_token @organization_id @extra_headers]
-
       vars = instance_variables.map do |var|
         value = instance_variable_get(var)
 
-        sensitive_attributes.include?(var) ? "#{var}=[REDACTED]" : "#{var}=#{value.inspect}"
+        SENSITIVE_ATTRIBUTES.include?(var) ? "#{var}=[REDACTED]" : "#{var}=#{value.inspect}"
       end
 
       "#<#{self.class}:#{object_id} #{vars.join(', ')}>"

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -107,5 +107,17 @@ module OpenAI
         client.add_headers("OpenAI-Beta": apis.map { |k, v| "#{k}=#{v}" }.join(";"))
       end
     end
+
+    def inspect
+      sensitive_attributes = %i[@access_token @organization_id @extra_headers]
+
+      vars = instance_variables.map do |var|
+        value = instance_variable_get(var)
+
+        sensitive_attributes.include?(var) ? "#{var}=[REDACTED]" : "#{var}=#{value.inspect}"
+      end
+
+      "#<#{self.class}:#{object_id} #{vars.join(', ')}>"
+    end
   end
 end

--- a/spec/openai/client/client_spec.rb
+++ b/spec/openai/client/client_spec.rb
@@ -133,4 +133,34 @@ RSpec.describe OpenAI::Client do
       expect(connection.builder.handlers).to include Faraday::Response::Logger
     end
   end
+
+  context "when calling inspect" do
+    let(:api_key) { "sk-123456789" }
+    let(:organization_id) { "org-123456789" }
+    let(:extra_headers) { { "Other-Auth": "key-123456789" } }
+    let(:uri_base) { "https://example.com/" }
+    let(:request_timeout) { 500 }
+    let(:client) do
+      OpenAI::Client.new(
+        uri_base: uri_base,
+        request_timeout: request_timeout,
+        access_token: api_key,
+        organization_id: organization_id,
+        extra_headers: extra_headers
+      )
+    end
+
+    it "does not expose sensitive information" do
+      expect(client.inspect).not_to include(api_key)
+      expect(client.inspect).not_to include(organization_id)
+      expect(client.inspect).not_to include(extra_headers[:"Other-Auth"])
+    end
+
+    it "does expose non-sensitive information" do
+      expect(client.inspect).to include(uri_base.inspect)
+      expect(client.inspect).to include(request_timeout.inspect)
+      expect(client.inspect).to include(client.object_id.to_s)
+      expect(client.inspect).to include(client.class.to_s)
+    end
+  end
 end


### PR DESCRIPTION
Updates the `.inspect` method for `OpenAI::Client` to obfuscate sensitive values by replace them with `[REDACTED]`. This should prevent accidental logging of API keys, etc.

Resolves alexrudall/ruby-openai#513

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
