### PR TITLE
Pass parameters through to List files endpoint

### DIFF
--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -11,8 +11,8 @@ module OpenAI
       @client = client
     end
 
-    def list
-      @client.get(path: "/files")
+    def list(parameters: {})
+      @client.get(path: "/files", parameters: parameters)
     end
 
     def upload(parameters: {})

--- a/spec/openai/client/client_spec.rb
+++ b/spec/openai/client/client_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe OpenAI::Client do
       end
 
       it "does not confuse the clients" do
-        expect(c0).to receive(:get).with(path: "/files").once
-        expect(c1).to receive(:get).with(path: "/files").once
-        expect(c2).to receive(:get).with(path: "/files").once
+        expect(c0).to receive(:get).with(path: "/files", parameters: {}).once
+        expect(c1).to receive(:get).with(path: "/files", parameters: {}).once
+        expect(c2).to receive(:get).with(path: "/files", parameters: {}).once
 
         expect(c0).to receive(:get).with(path: "/fine_tuning/jobs").once
         expect(c1).to receive(:get).with(path: "/fine_tuning/jobs").once


### PR DESCRIPTION
`purpose` is currently accepted but the gem doesn't allow for passing it in.

https://platform.openai.com/docs/api-reference/files/list#files-list-purpose

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
