### PR TITLE
Fix function example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,10 @@ response =
 message = response.dig("choices", 0, "message")
 
 if message["role"] == "assistant" && message["tool_calls"]
+
+  # For a subsequent message with the role "tool", OpenAI requires the preceding message to have a tool_calls argument.
+  messages << message
+
   message["tool_calls"].each do |tool_call|
     tool_call_id = tool_call.dig("id")
     function_name = tool_call.dig("function", "name")
@@ -503,9 +507,6 @@ if message["role"] == "assistant" && message["tool_calls"]
       else
         # decide how to handle
       end
-
-    # For a subsequent message with the role "tool", OpenAI requires the preceding message to have a tool_calls argument.
-    messages << message
 
     messages << {
       tool_call_id: tool_call_id,


### PR DESCRIPTION
I used the example code for function calling in one of my projects yesterday. It worked fine as long as there was only one item in `message["tool_calls"]`, but when multiple items were returned, the client responded with a 400 error for the `second_response`. After reviewing the official [function calling documentation](https://platform.openai.com/docs/guides/function-calling), I found that the message containing tool_calls is expected to appear only once, not for each item individually. This small change resolves the issue.
## All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
