### PR TITLE
docs(readme): add Faraday proxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ client = OpenAI::Client.new do |f|
 end
 ```
 
-- To add a web debugging proxy:
+- To add a web debugging proxy like [Charles](https://www.charlesproxy.com/documentation/welcome/):
 
 ```ruby
   client = OpenAI::Client.new do |f|

--- a/README.md
+++ b/README.md
@@ -235,7 +235,9 @@ client = OpenAI::Client.new(log_errors: true)
 
 ##### Faraday middleware
 
-You can pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg. to enable verbose logging with Ruby's [Logger](https://ruby-doc.org/3.2.2/stdlibs/logger/Logger.html):
+You can pass [Faraday middleware](https://lostisland.github.io/faraday/#/middleware/index) to the client in a block, eg:
+
+- To enable verbose logging with Ruby's [Logger](https://ruby-doc.org/3.2.2/stdlibs/logger/Logger.html):
 
 ```ruby
 client = OpenAI::Client.new do |f|
@@ -243,6 +245,13 @@ client = OpenAI::Client.new do |f|
 end
 ```
 
+- To add a web debugging proxy:
+
+```ruby
+  client = OpenAI::Client.new do |f|
+    f.proxy = { uri: "http://localhost:8888" }
+  end
+```
 #### Azure
 
 To use the [Azure OpenAI Service](https://learn.microsoft.com/en-us/azure/cognitive-services/openai/) API, you can configure the gem like this:


### PR DESCRIPTION
## Why

As per: https://github.com/alexrudall/ruby-openai/pull/502#issuecomment-2404652410 @alexrudall prefers to use the existing block form of `OpenAI::Client.new` to configure the Faraday middleware with a proxy.

## What

1. Changes the `##### Faraday middleware` section to support multiple use cases for passing a block to `OpenAI::Client.new`.
2. Adds an example which configures Faraday middleware with a web debugging proxy.

Obviates:
- https://github.com/alexrudall/ruby-openai/pull/502