### PR TITLE
ignore ruby-version, fix chat and completions api for azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ### Ruby ###
+.ruby-version
 *.gem
 *.rbc
 /.config

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -87,13 +87,13 @@ module OpenAI
     def build_azure_uri(path:, parameters: nil)
       case path
       when /\/chat\/completions\z/
-        base = File.join(@uri_base,'deployments',"#{parameters[:model]}",path)
+        base = File.join(@uri_base,'deployments', "#{parameters[:model]}",path)
       when /\/completions\z/
-        base = File.join(@uri_base,'deployments',"#{parameters[:model]}","chat",path)
+        base = File.join(@uri_base,'deployments', "#{parameters[:model]}","chat",path)
       else
-        base = File.join(@uri_base,path)
+        base = File.join(@uri_base, path)
       end
-      "#{base}?api-version=#{@api_version}" 
+      "#{base}?api-version=#{@api_version}"
     end
 
     def uri(path:,parameters: nil)


### PR DESCRIPTION
## All Submissions:

* [x ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?

Fixed the issue when using azure and trying to use either /chat or /completions api. Azure requires different base uri for /completions api. Extracted changes out to build_azure_uri and added parameters: nil to signature of uri method and adjusted calls in http.rb to add the parameters argument when available. Need access to model parameter to build the azure base_uri for /chat or /chat/completions