### PR TITLE
Update README to include Gemini instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Stream text with GPT-4o, transcribe and translate audio with Whisper, or create 
       - [Azure](#azure)
       - [Ollama](#ollama)
       - [Groq](#groq)
+      - [Gemini](#gemini)
     - [Counting Tokens](#counting-tokens)
     - [Models](#models)
     - [Chat](#chat)
@@ -275,6 +276,30 @@ client.chat(
     end
   }
 )
+```
+
+#### Gemini
+
+[Gemini API Chat](https://ai.google.dev/gemini-api/docs/openai) is also broadly compatible with the OpenAI API, and [currently in beta](https://ai.google.dev/gemini-api/docs/openai#current-limitations). Get an access token from [here](https://aistudio.google.com/app/apikey), then:
+
+```ruby
+client = OpenAI::Client.new(
+  access_token: "gemini_access_token_goes_here",
+  uri_base: "https://generativelanguage.googleapis.com/v1beta/openai/"
+)
+
+client.chat(
+  parameters: {
+    model: "gemini-1.5-flash", # Required.
+    messages: [{ role: "user", content: "Hello!"}], # Required.
+    temperature: 0.7,
+    stream: proc do |chunk, _bytesize|
+     print chunk.dig("choices", 0, "delta", "content")
+    end
+  }
+)
+
+# => Hello there! How can I help you today?
 ```
 
 ### Counting Tokens


### PR DESCRIPTION
Google Gemini Pro has an OpenAI-compatible API that works with this gem. I added a section in the README showing how to configure your gem to use Gemini.

## All Submissions:

* [X ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ X] Have you added an explanation of what your changes do and why you'd like us to include them?
