### PR TITLE
Add pricing calculation for OpenAI API responses (chat, embeddings and completions)

### DIFF
--- a/bin/scrape_pricing.rb
+++ b/bin/scrape_pricing.rb
@@ -1,0 +1,159 @@
+#!/usr/bin/env ruby
+
+require "playwright"
+require "base64"
+require_relative "../lib/openai"
+
+begin
+  playwright_path = `which playwright`.strip
+  abort "playwright not found. Please install playwright with `npm install -g playwright && playwright install`" if playwright_path.empty?
+  chrome_path = `which chrome`.strip
+  chrome_path = `which chromium`.strip if chrome_path.empty?
+  abort "Neither chromium nor chrome found. Please install chromium before continuing" if chrome_path.empty?
+
+  abort "OPENAI_ACCESS_TOKEN not set. Please set the OPENAI_ACCESS_TOKEN environment variable before continuing" if ENV["OPENAI_ACCESS_TOKEN"]&.empty?
+
+  pricing_data = ""
+  
+  Playwright.create(playwright_cli_executable_path: playwright_path) do |playwright|
+    chromium = playwright.chromium
+    browser = chromium.launch(
+      headless: false,
+      args: ["--window-size=1920,1080"]
+    )
+    
+    puts "reading pricing data from openai pricing page"
+    page = browser.new_page
+    page.goto("https://openai.com/api/pricing/")
+    
+    puts "Waiting for the page to be fully loaded"
+    page.wait_for_load_state(state: "domcontentloaded")
+
+    puts "extracting pricing data from the page"
+    elements = page.query_selector_all("div.m\\:max-w-container").take(5)
+    
+    pricing_data = elements.map do |element|
+      rows = element.query_selector_all("div.grid-cols-autofit")
+      rows.map do |row|
+        # Get all cells in the row
+        cells = row.query_selector_all("div.m\\:border-l-\\[1px\\]")
+        
+        # Extract text from each cell, strip whitespace, and filter out empty cells
+        row_data = cells.map { |cell| cell.text_content.strip }.reject(&:empty?)
+        row_data if row_data.any?
+      end.compact
+    end
+    
+    puts "\nPricing Table Data:"
+    pricing_data.each do |row|
+      puts row.join(" | ")
+    end
+    
+    browser.close
+  end
+
+  puts "processing pricing data"
+  OpenAI.configure do |config|
+    config.access_token = ENV.fetch("OPENAI_ACCESS_TOKEN")
+    config.log_errors = true # Highly recommended in development, so you can see what errors OpenAI is returning. Not recommended in production because it could leak private data to your logs.
+  end
+
+  client = OpenAI::Client.new    
+  messages = [
+    { 
+      role: "user", 
+      content: [
+        { 
+          type: "text", 
+          text: DATA.read.gsub("<%= pricing_data %>", pricing_data.to_s) 
+        }
+      ]
+    }
+  ]
+
+  response = client.chat(parameters: {
+    model: "gpt-4o-mini",
+    messages: messages
+  })
+
+
+  pricing = response.dig("choices", 0, "message", "content").strip.downcase
+  puts pricing
+rescue => e
+  puts "An error occurred: #{e.class} - #{e.message}"
+  puts e.backtrace
+end
+
+__END__
+
+You are a openai developer and salesperson. 
+I'll give you a pricing table and you'll extract the pricing details from each model.
+
+## Instructions
+
+Read the data provided in the `# Pricing data to process` section. 
+Extract the pricing details from each model.
+Format the data as a ruby hash with the following keys: 
+* model
+* input
+* cached input
+* output
+* audio input
+* audio output
+
+Use plain numbers for the prices without any currency notation.
+Take into account that audio-enabled models (e.g. gpt-4o-audio-preview-2024-12-17) there's no input cached nor batch pricing, take the values from the Text section. 
+
+Respond with the ruby hash as plain text without any formatting ready to be written to a ruby file.
+
+## Input data format
+
+The structure of the pricing data table for text-only models is:
+
+```
+<model> | <input> | <batch input> 
+<cached input>
+<output> | <cached output>
+```
+
+The structure of the pricing data table for audio-enabled models is:
+```
+<model> | "Text"
+<input> 
+<output>
+"Audio"
+<input> 
+<output>
+```
+## Example
+Given the following pricing data:
+
+```
+Pricing Table Data:
+gpt-4o | $2.50 / 1M input tokens | $1.25 / 1M input tokens
+$1.25 / 1M cached** input tokens
+$10.00 / 1M output tokens | $5.00 / 1M output tokens
+gpt-4o-2024-11-20 | $2.50 / 1M input tokens | $1.25 / 1M input tokens
+gpt-4o-audio-preview | Text
+$2.50 / 1M input tokens
+$10.00 / 1M output tokens
+Audio
+$40.00 / 1M input tokens
+$80.00 / 1M output tokens
+
+Pricing Table Data:
+o1-mini | $3.00 / 1M input tokens
+$1.50 / 1M cached* input tokens
+$12.00 / 1M output** tokens
+```
+
+the expected output is:
+{
+  "gpt-4o" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
+  "gpt-4o-audio-preview-2024-11-20" => {input: 2.5, cached_input: 2.5, output: 10.0, audio_input: 40.0, audio_output: 80.0},
+  "o1-mini" => {input: 3.0, cached_input: 1.5, output: 12.0, audio_input: nil, audio_output: nil},
+}
+
+## Pricing Data to process
+
+<%= pricing_data %>

--- a/data/costs_table.json
+++ b/data/costs_table.json
@@ -1,0 +1,142 @@
+{
+  "gpt-4o": {
+    "input": 2.5,
+    "cached_input": 1.25,
+    "output": 10.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "gpt-4o-2024-11-20": {
+    "input": 2.5,
+    "cached_input": 1.25,
+    "output": 10.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "gpt-4o-2024-08-06": {
+    "input": 2.5,
+    "cached_input": 1.25,
+    "output": 10.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "gpt-4o-audio-preview": {
+    "input": 2.5,
+    "cached_input": null,
+    "output": 10.0,
+    "audio_input": 40.0,
+    "audio_output": 80.0
+  },
+  "gpt-4o-audio-preview-2024-12-17": {
+    "input": 2.5,
+    "cached_input": null,
+    "output": 10.0,
+    "audio_input": 40.0,
+    "audio_output": 80.0
+  },
+  "gpt-4o-audio-preview-2024-10-01": {
+    "input": 2.5,
+    "cached_input": null,
+    "output": 10.0,
+    "audio_input": 100.0,
+    "audio_output": 200.0
+  },
+  "gpt-4o-2024-05-13": {
+    "input": 5.0,
+    "cached_input": 2.5,
+    "output": 15.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "gpt-4o-mini": {
+    "input": 0.15,
+    "cached_input": 0.075,
+    "output": 0.6,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "gpt-4o-mini-2024-07-18": {
+    "input": 0.15,
+    "cached_input": 0.075,
+    "output": 0.6,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "gpt-4o-mini-audio-preview": {
+    "input": 0.15,
+    "cached_input": null,
+    "output": 0.6,
+    "audio_input": 10.0,
+    "audio_output": 20.0
+  },
+  "gpt-4o-mini-audio-preview-2024-12-17": {
+    "input": 0.15,
+    "cached_input": null,
+    "output": 0.6,
+    "audio_input": 10.0,
+    "audio_output": 20.0
+  },
+  "o1": {
+    "input": 15.0,
+    "cached_input": 7.5,
+    "output": 60.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "o1-2024-12-17": {
+    "input": 15.0,
+    "cached_input": 7.5,
+    "output": 60.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "o1-preview": {
+    "input": 15.0,
+    "cached_input": 7.5,
+    "output": 60.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "o1-preview-2024-09-12": {
+    "input": 15.0,
+    "cached_input": 7.5,
+    "output": 60.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "o1-mini": {
+    "input": 3.0,
+    "cached_input": 1.5,
+    "output": 12.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "o1-mini-2024-09-12": {
+    "input": 3.0,
+    "cached_input": 1.5,
+    "output": 12.0,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "text-embedding-3-small": {
+    "input": 0.02,
+    "cached_input": 0.01,
+    "output": null,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "text-embedding-3-large": {
+    "input": 0.13,
+    "cached_input": 0.065,
+    "output": null,
+    "audio_input": null,
+    "audio_output": null
+  },
+  "ada v2": {
+    "input": 0.1,
+    "cached_input": 0.05,
+    "output": null,
+    "audio_input": null,
+    "audio_output": null
+  }
+}

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -18,9 +18,10 @@ require_relative "openai/vector_store_file_batches"
 require_relative "openai/audio"
 require_relative "openai/version"
 require_relative "openai/batches"
-
+require_relative "openai/pricing"
 module OpenAI
   class Error < StandardError; end
+
   class ConfigurationError < Error; end
 
   class MiddlewareErrors < Faraday::Middleware

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -44,6 +44,7 @@ module OpenAI
     attr_accessor :access_token,
                   :api_type,
                   :api_version,
+                  :costs_table_path,
                   :log_errors,
                   :organization_id,
                   :uri_base,
@@ -59,6 +60,7 @@ module OpenAI
       @access_token = nil
       @api_type = nil
       @api_version = DEFAULT_API_VERSION
+      @costs_table_path = File.expand_path("../data/costs_table.json", __dir__)
       @log_errors = DEFAULT_LOG_ERRORS
       @organization_id = nil
       @uri_base = DEFAULT_URI_BASE

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -116,7 +116,7 @@ module OpenAI
         SENSITIVE_ATTRIBUTES.include?(var) ? "#{var}=[REDACTED]" : "#{var}=#{value.inspect}"
       end
 
-      "#<#{self.class}:#{object_id} #{vars.join(", ")}>"
+      "#<#{self.class}:#{object_id} #{vars.join(', ')}>"
     end
 
     private

--- a/lib/openai/pricing.rb
+++ b/lib/openai/pricing.rb
@@ -1,34 +1,19 @@
+# rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/MethodLength
 module OpenAI
   class Pricing
-    COSTS = {
-      "gpt-4o" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
-      "gpt-4o-2024-11-20" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
-      "gpt-4o-2024-08-06" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
-      "gpt-4o-audio-preview" => {input: 2.5, cached_input: nil, output: 10.0, audio_input: 40.0, audio_output: 80.0},
-      "gpt-4o-audio-preview-2024-12-17" => {input: 2.5, cached_input: nil, output: 10.0, audio_input: 40.0, audio_output: 80.0},
-      "gpt-4o-audio-preview-2024-10-01" => {input: 2.5, cached_input: nil, output: 10.0, audio_input: 100.0, audio_output: 200.0},
-      "gpt-4o-2024-05-13" => {input: 5.0, cached_input: 2.5, output: 15.0, audio_input: nil, audio_output: nil},
-      "gpt-4o-mini" => {input: 0.15, cached_input: 0.075, output: 0.6, audio_input: nil, audio_output: nil},
-      "gpt-4o-mini-2024-07-18" => {input: 0.15, cached_input: 0.075, output: 0.6, audio_input: nil, audio_output: nil},
-      "gpt-4o-mini-audio-preview" => {input: 0.15, cached_input: nil, output: 0.6, audio_input: 10.0, audio_output: 20.0},
-      "gpt-4o-mini-audio-preview-2024-12-17" => {input: 0.15, cached_input: nil, output: 0.6, audio_input: 10.0, audio_output: 20.0},
-      "o1" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
-      "o1-2024-12-17" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
-      "o1-preview" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
-      "o1-preview-2024-09-12" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
-      "o1-mini" => {input: 3.0, cached_input: 1.5, output: 12.0, audio_input: nil, audio_output: nil},
-      "o1-mini-2024-09-12" => {input: 3.0, cached_input: 1.5, output: 12.0, audio_input: nil, audio_output: nil},
-      "text-embedding-3-small" => {input: 0.02, cached_input: 0.01, output: nil, audio_input: nil, audio_output: nil},
-      "text-embedding-3-large" => {input: 0.13, cached_input: 0.065, output: nil, audio_input: nil, audio_output: nil},
-      "ada v2" => {input: 0.1, cached_input: 0.05, output: nil, audio_input: nil, audio_output: nil}
-    }
-    
+    class << self
+      def costs_table
+        @costs_table ||= JSON.parse(File.read(OpenAI.configuration.costs_table_path))
+      end
+    end
 
     def self.calculate(response)
       new.calculate(response)
     end
 
-    def calculate(response, costs = COSTS)
+    def calculate(response)
+      costs = self.class.costs_table
       model = response["model"]
       usage = response["usage"]
       pricing = costs[model]
@@ -36,7 +21,7 @@ module OpenAI
       return {} if [model, usage, pricing].any? { |val| val.nil? || val.empty? }
 
       pricing = pricing.transform_values { |v| (v || 0) / 1_000_000.0 }
-      
+
       prompt_costs = calculate_prompt_costs(usage, pricing)
       completion_costs = calculate_completion_costs(usage, pricing)
 
@@ -102,3 +87,5 @@ module OpenAI
     end
   end
 end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength

--- a/lib/openai/pricing.rb
+++ b/lib/openai/pricing.rb
@@ -1,0 +1,104 @@
+module OpenAI
+  class Pricing
+    COSTS = {
+      "gpt-4o" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
+      "gpt-4o-2024-11-20" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
+      "gpt-4o-2024-08-06" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
+      "gpt-4o-audio-preview" => {input: 2.5, cached_input: nil, output: 10.0, audio_input: 40.0, audio_output: 80.0},
+      "gpt-4o-audio-preview-2024-12-17" => {input: 2.5, cached_input: nil, output: 10.0, audio_input: 40.0, audio_output: 80.0},
+      "gpt-4o-audio-preview-2024-10-01" => {input: 2.5, cached_input: nil, output: 10.0, audio_input: 100.0, audio_output: 200.0},
+      "gpt-4o-2024-05-13" => {input: 5.0, cached_input: 2.5, output: 15.0, audio_input: nil, audio_output: nil},
+      "gpt-4o-mini" => {input: 0.15, cached_input: 0.075, output: 0.6, audio_input: nil, audio_output: nil},
+      "gpt-4o-mini-2024-07-18" => {input: 0.15, cached_input: 0.075, output: 0.6, audio_input: nil, audio_output: nil},
+      "gpt-4o-mini-audio-preview" => {input: 0.15, cached_input: nil, output: 0.6, audio_input: 10.0, audio_output: 20.0},
+      "gpt-4o-mini-audio-preview-2024-12-17" => {input: 0.15, cached_input: nil, output: 0.6, audio_input: 10.0, audio_output: 20.0},
+      "o1" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
+      "o1-2024-12-17" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
+      "o1-preview" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
+      "o1-preview-2024-09-12" => {input: 15.0, cached_input: 7.5, output: 60.0, audio_input: nil, audio_output: nil},
+      "o1-mini" => {input: 3.0, cached_input: 1.5, output: 12.0, audio_input: nil, audio_output: nil},
+      "o1-mini-2024-09-12" => {input: 3.0, cached_input: 1.5, output: 12.0, audio_input: nil, audio_output: nil},
+      "text-embedding-3-small" => {input: 0.02, cached_input: 0.01, output: nil, audio_input: nil, audio_output: nil},
+      "text-embedding-3-large" => {input: 0.13, cached_input: 0.065, output: nil, audio_input: nil, audio_output: nil},
+      "ada v2" => {input: 0.1, cached_input: 0.05, output: nil, audio_input: nil, audio_output: nil}
+    }
+    
+
+    def self.calculate(response)
+      new.calculate(response)
+    end
+
+    def calculate(response, costs = COSTS)
+      model = response["model"]
+      usage = response["usage"]
+      pricing = costs[model]
+
+      return {} if [model, usage, pricing].any? { |val| val.nil? || val.empty? }
+
+      pricing = pricing.transform_values { |v| (v || 0) / 1_000_000.0 }
+      
+      prompt_costs = calculate_prompt_costs(usage, pricing)
+      completion_costs = calculate_completion_costs(usage, pricing)
+
+      {
+        prompt_cost: prompt_costs[:total],
+        completion_cost: completion_costs[:total],
+        total_cost: prompt_costs[:total] + completion_costs[:total],
+        prompt_cost_details: {
+          cached_cost: prompt_costs[:cached],
+          audio_cost: prompt_costs[:audio]
+        },
+        completion_cost_details: {
+          reasoning_cost: completion_costs[:reasoning],
+          audio_cost: completion_costs[:audio],
+          accepted_prediction_cost: completion_costs[:accepted_prediction],
+          rejected_prediction_cost: completion_costs[:rejected_prediction]
+        }
+      }
+    end
+
+    private
+
+    def calculate_prompt_costs(usage, pricing)
+      details = usage["prompt_tokens_details"] || {}
+
+      cached_tokens = details["cached_tokens"] || 0
+      audio_tokens = details["audio_tokens"] || 0
+      regular_tokens = usage["prompt_tokens"] - cached_tokens - audio_tokens
+
+      cached_cost = cached_tokens * pricing[:cached_input]
+      audio_cost = audio_tokens * pricing[:audio_input]
+      regular_cost = regular_tokens * pricing[:input]
+
+      {
+        total: cached_cost + audio_cost + regular_cost,
+        cached: cached_cost,
+        audio: audio_cost
+      }
+    end
+
+    def calculate_completion_costs(usage, pricing)
+      details = usage["completion_tokens_details"] || {}
+
+      reasoning_tokens = details["reasoning_tokens"] || 0
+      audio_tokens = details["audio_tokens"] || 0
+      accepted_prediction_tokens = details["accepted_prediction_tokens"] || 0
+      rejected_prediction_tokens = details["rejected_prediction_tokens"] || 0
+      regular_tokens = usage["completion_tokens"] - audio_tokens
+
+      reasoning_cost = reasoning_tokens * pricing[:output]
+      audio_cost = audio_tokens * pricing[:audio_output]
+      accepted_prediction_cost = accepted_prediction_tokens * pricing[:output]
+      rejected_prediction_cost = rejected_prediction_tokens * pricing[:output]
+      regular_cost = regular_tokens * pricing[:output]
+
+      {
+        total: regular_cost + audio_cost,
+        reasoning: reasoning_cost,
+        audio: audio_cost,
+        accepted_prediction: accepted_prediction_cost,
+        rejected_prediction: rejected_prediction_cost
+      }
+    end
+  end
+end

--- a/spec/fixtures/cassettes/gpt-3_5-turbo_chat.yml
+++ b/spec/fixtures/cassettes/gpt-3_5-turbo_chat.yml
@@ -23,47 +23,37 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 26 Nov 2023 11:45:46 GMT
+      - Mon, 13 Jan 2025 12:50:43 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      Access-Control-Allow-Origin:
-      - "*"
-      Cache-Control:
-      - no-cache, must-revalidate
-      Openai-Model:
-      - gpt-3.5-turbo-0613
+      Access-Control-Expose-Headers:
+      - X-Request-ID
       Openai-Organization:
       - user-jxm65ijkzc1qrfhc0ij8moic
       Openai-Processing-Ms:
-      - '1065'
+      - '258'
       Openai-Version:
       - '2020-10-01'
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
       X-Ratelimit-Limit-Requests:
-      - '3500'
+      - '10000'
       X-Ratelimit-Limit-Tokens:
-      - '90000'
-      X-Ratelimit-Limit-Tokens-Usage-Based:
-      - '90000'
+      - '200000'
       X-Ratelimit-Remaining-Requests:
-      - '3499'
+      - '9999'
       X-Ratelimit-Remaining-Tokens:
-      - '89980'
-      X-Ratelimit-Remaining-Tokens-Usage-Based:
-      - '89980'
+      - '199981'
       X-Ratelimit-Reset-Requests:
-      - 17ms
+      - 8.64s
       X-Ratelimit-Reset-Tokens:
-      - 12ms
-      X-Ratelimit-Reset-Tokens-Usage-Based:
-      - 12ms
+      - 5ms
       X-Request-Id:
-      - d37ce9eab44ed35275edd3b48ca62658
+      - req_79dffb9126ab277aeae17d13f19862a7
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Cf-Cache-Status:
       - DYNAMIC
       Set-Cookie:
@@ -75,32 +65,46 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 82c1e3120f500acb-MAN
+      - 7b15d86a4a0edd70-LHR
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: ASCII-8BIT
       string: |
         {
-          "id": "chatcmpl-8P7s1c2QVZW1Uqqd11S0cB78LBvoA",
+          "id": "chatcmpl-ApEBuZmSu5v0WhXCz19jR6O7garIm",
           "object": "chat.completion",
-          "created": 1700999145,
-          "model": "gpt-3.5-turbo-0613",
+          "created": 1736772642,
+          "model": "gpt-3.5-turbo-0125",
           "choices": [
             {
               "index": 0,
               "message": {
                 "role": "assistant",
-                "content": "Hi there! How can I assist you today?"
+                "content": "Hello! How can I assist you today?",
+                "refusal": null
               },
+              "logprobs": null,
               "finish_reason": "stop"
             }
           ],
           "usage": {
             "prompt_tokens": 9,
             "completion_tokens": 10,
-            "total_tokens": 19
-          }
+            "total_tokens": 19,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": null
         }
-  recorded_at: Sun, 26 Nov 2023 11:45:46 GMT
+  recorded_at: Mon, 13 Jan 2025 12:50:43 GMT
 recorded_with: VCR 6.1.0

--- a/spec/openai/client/pricing_spec.rb
+++ b/spec/openai/client/pricing_spec.rb
@@ -1,28 +1,48 @@
-RSpec.describe OpenAI::Pricing do
-  COSTS = {
-    "gpt-4o" => {input: 2.50, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
-    "gpt-4o-audio-preview" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: 40.0, audio_output: 80.0}
-  }
+module OpenAI
+  class Pricing
+    # rubocop:disable Metrics/MethodLength
+    def self.costs_table
+      {
+        "gpt-4o" => {
+          input: 2.50,
+          cached_input: 1.25,
+          output: 10.0,
+          audio_input: nil,
+          audio_output: nil
+        },
+        "gpt-4o-audio-preview" => {
+          input: 2.5,
+          cached_input: 1.25,
+          output: 10.0,
+          audio_input: 40.0,
+          audio_output: 80.0
+        }
+      }.freeze
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end
 
+RSpec.describe OpenAI::Pricing do
   describe ".calculate" do
     context "with invalid inputs" do
       it "returns empty hash when model is nil" do
-        response = described_class.new.calculate({"model" => nil}, COSTS)
+        response = described_class.new.calculate({ "model" => nil })
         expect(response).to eq({})
       end
 
       it "returns empty hash when model is empty" do
-        response = described_class.new.calculate({"model" => ""}, COSTS)
+        response = described_class.new.calculate({ "model" => "" })
         expect(response).to eq({})
       end
 
       it "returns empty hash when usage is empty" do
-        response = described_class.new.calculate({"model" => "gpt-4o", "usage" => {}}, COSTS)
+        response = described_class.new.calculate({ "model" => "gpt-4o", "usage" => {} })
         expect(response).to eq({})
       end
 
       it "returns empty hash when usage is nil" do
-        response = described_class.new.calculate({"model" => "gpt-4o", "usage" => nil}, COSTS)
+        response = described_class.new.calculate({ "model" => "gpt-4o", "usage" => nil })
         expect(response).to eq({})
       end
     end
@@ -48,9 +68,9 @@ RSpec.describe OpenAI::Pricing do
           }
         }
 
-        result = described_class.new.calculate(response, COSTS)
+        result = described_class.new.calculate(response)
 
-        expect(result[:prompt_cost]).to eq(0.0001875, )
+        expect(result[:prompt_cost]).to eq(0.0001875)
         expect(result[:completion_cost]).to eq(0.002)
         expect(result[:total_cost]).to eq(0.0021875)
 
@@ -87,9 +107,9 @@ RSpec.describe OpenAI::Pricing do
           }
         }
 
-        result = described_class.new.calculate(response, COSTS)
+        result = described_class.new.calculate(response)
 
-        expect(result[:prompt_cost]).to eq(0.004375, )
+        expect(result[:prompt_cost]).to eq(0.004375)
         expect(result[:completion_cost]).to eq(0.012)
         expect(result[:total_cost]).to eq(0.016375)
 

--- a/spec/openai/client/pricing_spec.rb
+++ b/spec/openai/client/pricing_spec.rb
@@ -1,0 +1,106 @@
+RSpec.describe OpenAI::Pricing do
+  COSTS = {
+    "gpt-4o" => {input: 2.50, cached_input: 1.25, output: 10.0, audio_input: nil, audio_output: nil},
+    "gpt-4o-audio-preview" => {input: 2.5, cached_input: 1.25, output: 10.0, audio_input: 40.0, audio_output: 80.0}
+  }
+
+  describe ".calculate" do
+    context "with invalid inputs" do
+      it "returns empty hash when model is nil" do
+        response = described_class.new.calculate({"model" => nil}, COSTS)
+        expect(response).to eq({})
+      end
+
+      it "returns empty hash when model is empty" do
+        response = described_class.new.calculate({"model" => ""}, COSTS)
+        expect(response).to eq({})
+      end
+
+      it "returns empty hash when usage is empty" do
+        response = described_class.new.calculate({"model" => "gpt-4o", "usage" => {}}, COSTS)
+        expect(response).to eq({})
+      end
+
+      it "returns empty hash when usage is nil" do
+        response = described_class.new.calculate({"model" => "gpt-4o", "usage" => nil}, COSTS)
+        expect(response).to eq({})
+      end
+    end
+
+    context "with text only prompt and completion" do
+      it "calculates all costs correctly" do
+        response = {
+          "model" => "gpt-4o",
+          "usage" => {
+            "prompt_tokens" => 100,
+            "completion_tokens" => 200,
+            "total_tokens" => 300,
+            "prompt_tokens_details" => {
+              "cached_tokens" => 50,
+              "audio_tokens" => 0
+            },
+            "completion_tokens_details" => {
+              "reasoning_tokens" => 0,
+              "audio_tokens" => 0,
+              "accepted_prediction_tokens" => 0,
+              "rejected_prediction_tokens" => 0
+            }
+          }
+        }
+
+        result = described_class.new.calculate(response, COSTS)
+
+        expect(result[:prompt_cost]).to eq(0.0001875, )
+        expect(result[:completion_cost]).to eq(0.002)
+        expect(result[:total_cost]).to eq(0.0021875)
+
+        expect(result.dig(:prompt_cost_details, :cached_cost)).to eq(0.0000625)
+        expect(result.dig(:prompt_cost_details, :audio_cost)).to eq(0.0)
+
+        expect(result.dig(:completion_cost_details, :reasoning_cost)).to eq(0)
+        expect(result.dig(:completion_cost_details, :audio_cost)).to eq(0)
+        expect(result.dig(:completion_cost_details, :accepted_prediction_cost)).to eq(0)
+        expect(result.dig(:completion_cost_details, :rejected_prediction_cost)).to eq(0)
+      end
+    end
+
+    context "with text + audio prompt and completion" do
+      it "calculates all costs correctly" do
+        response = {
+          "model" => "gpt-4o-audio-preview",
+          "usage" => {
+            "prompt_tokens" => 300,
+            "completion_tokens" => 500,
+            "total_tokens" => 700,
+            "prompt_tokens_details" => {
+              "cached_tokens" => 100,
+              "audio_tokens" => 100
+              #=> 100 non-cached text tokens
+            },
+            "completion_tokens_details" => {
+              "reasoning_tokens" => 100,
+              "audio_tokens" => 100,
+              "accepted_prediction_tokens" => 100,
+              "rejected_prediction_tokens" => 100
+              #=> 100 text tokens
+            }
+          }
+        }
+
+        result = described_class.new.calculate(response, COSTS)
+
+        expect(result[:prompt_cost]).to eq(0.004375, )
+        expect(result[:completion_cost]).to eq(0.012)
+        expect(result[:total_cost]).to eq(0.016375)
+
+        expect(result.dig(:prompt_cost_details, :cached_cost)).to eq(0.000125)
+        expect(result.dig(:prompt_cost_details, :audio_cost)).to eq(0.004)
+
+        expect(result.dig(:completion_cost_details, :reasoning_cost)).to eq(0.001)
+        expect(result.dig(:completion_cost_details, :audio_cost)).to eq(0.008)
+        expect(result.dig(:completion_cost_details, :accepted_prediction_cost)).to eq(0.001)
+        expect(result.dig(:completion_cost_details, :rejected_prediction_cost)).to eq(0.001)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add new OpenAI::Pricing class to calculate costs based on token usage
- Integrate automatic cost calculation into API response handling
- Include detailed cost breakdown for:
  - Input tokens (regular, cached, audio)
  - Output tokens (regular, reasoning, audio, predictions)

The pricing data supports all current OpenAI models including GPT-4, embeddings, and audio-enabled variants.
Costs are automatically merged into API responses under a new 'cost' key that follows the structure of the "usage" key

Bonus:
- a script to fetch latest model costs from OpenAI website

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
