### PR TITLE
Added new Responses API

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -32,6 +32,10 @@ module OpenAI
       json_post(path: "/completions", parameters: parameters)
     end
 
+    def responses(parameters: {})
+      json_post(path: "/responses", parameters: parameters)
+    end
+
     def audio
       @audio ||= OpenAI::Audio.new(client: self)
     end

--- a/spec/fixtures/cassettes/gpt-4o_responsesapi_responses.yml
+++ b/spec/fixtures/cassettes/gpt-4o_responsesapi_responses.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","input":"Hello!","stream":false}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 12 Mar 2025 16:59:36 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - tropic-7
+      X-Request-Id:
+      - req_3d66e8cf8ab939e291495082981f44ed
+      Openai-Processing-Ms:
+      - '662'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=Mfr11XiUuv0c9VCLx5B2NXyT2zi7X0iwufNkjRC7Ks0-1741798776-1.0.1.1-tbYGWj30sUavRX.GkIfoLMHw9oQZ5whT.5WbXz76ojOBPbp6zrYW5RZLYROyVfBJOcqwD0H2EGZ8_Ta1kvYSetWXicdnzqFPwh2AHNE68F0;
+        path=/; expires=Wed, 12-Mar-25 17:29:36 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=mtXjqFLJleHJjAOzTR1A6sHit8qH5N2UXi9cLdqnKxs-1741798776971-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91f4d7ceab3dc01c-WAW
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_67d1bd7838548191bf6ef926331dae9d04c5a42cd404ab4d",
+          "object": "response",
+          "created_at": 1741798776,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "model": "gpt-4o-2024-08-06",
+          "output": [
+            {
+              "type": "message",
+              "id": "msg_67d1bd7898c08191b36d9e7920aeb09104c5a42cd404ab4d",
+              "status": "completed",
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "output_text",
+                  "text": "Hi there! How can I assist you today?",
+                  "annotations": []
+                }
+              ]
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "reasoning": {
+            "effort": null,
+            "generate_summary": null
+          },
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 27,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 11,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 38
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Wed, 12 Mar 2025 16:59:36 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/gpt-4o_streamed_responsesapi_responses.yml
+++ b/spec/fixtures/cassettes/gpt-4o_streamed_responsesapi_responses.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","input":"Hello!","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 12 Mar 2025 16:59:40 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - tropic-7
+      X-Request-Id:
+      - req_fa50380d9311693c3f763a22b24eee77
+      Openai-Processing-Ms:
+      - '51'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=IY3ThYrVK7alqLEMbB1twLEG88Bef1OUz6pWWgkYrfE-1741798780-1.0.1.1-s5avIb8RUXCHgZmfvWToJkH_uELi5H6BS0QtoSVSISmg9.RBA7Z97ySYNXZ6Czt7RZnT.K6Pj9W5u3NDNf6u4rroFm_BAWRyUaZUHgbnkR0;
+        path=/; expires=Wed, 12-Mar-25 17:29:40 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=tjwk_Z09jnlOWbISJrfgtJrv.wn3k_50UJ9uEAnlEU0-1741798780709-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91f4d7e9c902b1b8-WAW
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_67d1bd7c931c8191870ad798c711562004d0a3fcf4e20298","object":"response","created_at":1741798780,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_67d1bd7c931c8191870ad798c711562004d0a3fcf4e20298","object":"response","created_at":1741798780,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","status":"in_progress","role":"assistant","content":[]}}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":"Hi"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" there"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":"!"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" How"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" can"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" I"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" assist"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" you"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":" today"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"delta":"?"}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"text":"Hi there! How can I assist you today?"}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","item_id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hi there! How can I assist you today?","annotations":[]}}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hi there! How can I assist you today?","annotations":[]}]}}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_67d1bd7c931c8191870ad798c711562004d0a3fcf4e20298","object":"response","created_at":1741798780,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[{"type":"message","id":"msg_67d1bd7ce24c819188993565819babf404d0a3fcf4e20298","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hi there! How can I assist you today?","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":27,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38},"user":null,"metadata":{}}}
+
+  recorded_at: Wed, 12 Mar 2025 16:59:41 GMT
+recorded_with: VCR 6.1.0
+...

--- a/spec/fixtures/cassettes/gpt-4o_streamed_responsesapi_responses_without_proc.yml
+++ b/spec/fixtures/cassettes/gpt-4o_streamed_responsesapi_responses_without_proc.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","input":"Hello!","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 12 Mar 2025 16:59:41 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - tropic-7
+      X-Request-Id:
+      - req_414f16578028c0eb2b069f7b432e3295
+      Openai-Processing-Ms:
+      - '49'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=0NdTwntvQEF8dhhtjmAl_gp.Fhi.sQt3RpaSON8QhS8-1741798781-1.0.1.1-Mfavia6gZWi39FRvtcZHkOcCZSZS4f42r6YqsEWbFaRnV7uuxmkPIybJeRYUjeoL2NPc18NiB8v_Yy0oItNbQlEx.o_RjhGvHjULaFh3NpQ;
+        path=/; expires=Wed, 12-Mar-25 17:29:41 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=OUUntiT9Ncab.L9S1KUh21L.iwScGzutHrvPMo8iuYs-1741798781592-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91f4d7ef6aebef93-WAW
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        event: response.created
+        data: {"type":"response.created","response":{"id":"resp_67d1bd7d75808191b19bd19ab4bd552a0871fadd43c1e9b4","object":"response","created_at":1741798781,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","response":{"id":"resp_67d1bd7d75808191b19bd19ab4bd552a0871fadd43c1e9b4","object":"response","created_at":1741798781,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","status":"in_progress","role":"assistant","content":[]}}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"part":{"type":"output_text","text":"","annotations":[]}}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":"Hi"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" there"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":"!"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" How"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" can"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" I"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" assist"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" you"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":" today"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"delta":"?"}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"text":"Hi there! How can I assist you today?"}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","item_id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","output_index":0,"content_index":0,"part":{"type":"output_text","text":"Hi there! How can I assist you today?","annotations":[]}}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hi there! How can I assist you today?","annotations":[]}]}}
+
+        event: response.completed
+        data: {"type":"response.completed","response":{"id":"resp_67d1bd7d75808191b19bd19ab4bd552a0871fadd43c1e9b4","object":"response","created_at":1741798781,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-4o-2024-08-06","output":[{"type":"message","id":"msg_67d1bd7dd56881918d42ec516d7681600871fadd43c1e9b4","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Hi there! How can I assist you today?","annotations":[]}]}],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"generate_summary":null},"store":true,"temperature":1.0,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":27,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":38},"user":null,"metadata":{}}}
+
+  recorded_at: Wed, 12 Mar 2025 16:59:42 GMT
+recorded_with: VCR 6.1.0
+...

--- a/spec/fixtures/cassettes/gpt-4o_valid_tool_call_responsesapi_responses.yml
+++ b/spec/fixtures/cassettes/gpt-4o_valid_tool_call_responsesapi_responses.yml
@@ -1,0 +1,135 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","input":"What is the weather like in the Peak District?","stream":false,"tools":[{"type":"function","name":"get_current_weather","description":"Get
+        the current weather in a given location","parameters":{"type":"object","properties":{"location":{"type":"string","description":"The
+        geographic location to get the weather for"}},"required":["location"]}}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 12 Mar 2025 16:59:40 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - tropic-7
+      X-Request-Id:
+      - req_7576f65fceb4761f57674f6036a97a16
+      Openai-Processing-Ms:
+      - '718'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=zsBa8zzM5XeGXfIZj9WLik3iW4nxV4BkHwgOp8w2VYE-1741798780-1.0.1.1-VbaoulWxc2gxi_8f8X3sn7FFyZr2bh9W5RWNhp9xL9Pb1HfAtt_jjgY_4Om_mhY5zPDxsYGByW.gEkjtL8bGfsFM4uWI6ViQXJIOmlxihTU;
+        path=/; expires=Wed, 12-Mar-25 17:29:40 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=5Lm6TRl2k0DmlAFx_Fzr8EztRlBS8mnbjnghZCBsN_8-1741798780381-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91f4d7e2bcc9ecb3-WAW
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_67d1bd7b96508191b78a43b809c2a6b804541f6e0fe60866",
+          "object": "response",
+          "created_at": 1741798779,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "model": "gpt-4o-2024-08-06",
+          "output": [
+            {
+              "type": "function_call",
+              "id": "fc_67d1bd7c22bc8191904dc1180edc277804541f6e0fe60866",
+              "call_id": "call_gdFtKNOAxjykUcoLyb6YovEc",
+              "name": "get_current_weather",
+              "arguments": "{\"location\":\"Peak District\"}",
+              "status": "completed"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "reasoning": {
+            "effort": null,
+            "generate_summary": null
+          },
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [
+            {
+              "type": "function",
+              "description": "Get the current weather in a given location",
+              "name": "get_current_weather",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string",
+                    "description": "The geographic location to get the weather for"
+                  }
+                },
+                "required": [
+                  "location"
+                ]
+              },
+              "strict": true
+            }
+          ],
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 277,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 17,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 294
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Wed, 12 Mar 2025 16:59:40 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/gpt-4o_with_followup_message_responsesapi_responses.yml
+++ b/spec/fixtures/cassettes/gpt-4o_with_followup_message_responsesapi_responses.yml
@@ -1,0 +1,235 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","input":"Hello! My name is Szymon.","stream":false}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 12 Mar 2025 16:59:38 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - tropic-7
+      X-Request-Id:
+      - req_b15024573b1c3825a46b7221c061bc7a
+      Openai-Processing-Ms:
+      - '919'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=BPeSAFNKBfTqeBW5n.dBz8e9z2klt4D9Kxg5rhza7to-1741798778-1.0.1.1-a9AG6LL5DoaL82GXSt.5i6zyz12b_uWNnGoFyxVpBExjlN3Dp5MqssoFKGiPnD7X5PWRBUHmtKIqvA1b3lrMSjuQiomTl4RsybezImlABdc;
+        path=/; expires=Wed, 12-Mar-25 17:29:38 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=IXgbJlzrSR9DfQMTC8uTeULkfWecpjlTf0frEY5DCv4-1741798778161-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91f4d7d48f2434ee-WAW
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_67d1bd7929c08191ad4739df2905b4e60556135678e460e1",
+          "object": "response",
+          "created_at": 1741798777,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "model": "gpt-4o-2024-08-06",
+          "output": [
+            {
+              "type": "message",
+              "id": "msg_67d1bd797ea881918ab706999a5abdf70556135678e460e1",
+              "status": "completed",
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "output_text",
+                  "text": "Hello, Szymon! How can I assist you today?",
+                  "annotations": []
+                }
+              ]
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "reasoning": {
+            "effort": null,
+            "generate_summary": null
+          },
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 34,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 14,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 48
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Wed, 12 Mar 2025 16:59:38 GMT
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o","input":"Remind me, what is my name?","stream":false,"previous_response_id":"resp_67d1bd7929c08191ad4739df2905b4e60556135678e460e1"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_ACCESS_TOKEN>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 12 Mar 2025 16:59:39 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - tropic-7
+      X-Request-Id:
+      - req_116f9068df609498f6ac98f5c52ed64e
+      Openai-Processing-Ms:
+      - '806'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=mDhUa0s5BaQpKa7LTZgsmklXFha._mmHZguojJfnL2w-1741798779-1.0.1.1-s3ykNAwR.rzG6XJNxRwbO99KIhoXfkIKmKIxFr6AfOEDMmVLEk3Kx9qLhytHMYZjhssOHwtvrtLTLC4thaPfYttPk7bs1VsVucSGYG5IsNc;
+        path=/; expires=Wed, 12-Mar-25 17:29:39 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=ex9XnQNtPx4IuPxQXucgeua5wL4YIuRC2ZZcKGWjLuk-1741798779243-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 91f4d7dbe9483536-WAW
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_67d1bd7a56b48191836d63d55cbb96620556135678e460e1",
+          "object": "response",
+          "created_at": 1741798778,
+          "status": "completed",
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "model": "gpt-4o-2024-08-06",
+          "output": [
+            {
+              "type": "message",
+              "id": "msg_67d1bd7aeb908191861ad7727dad09d70556135678e460e1",
+              "status": "completed",
+              "role": "assistant",
+              "content": [
+                {
+                  "type": "output_text",
+                  "text": "Your name is Szymon.",
+                  "annotations": []
+                }
+              ]
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": "resp_67d1bd7929c08191ad4739df2905b4e60556135678e460e1",
+          "reasoning": {
+            "effort": null,
+            "generate_summary": null
+          },
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            }
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 64,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 8,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 72
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Wed, 12 Mar 2025 16:59:39 GMT
+recorded_with: VCR 6.1.0

--- a/spec/openai/client/responses_spec.rb
+++ b/spec/openai/client/responses_spec.rb
@@ -1,0 +1,157 @@
+RSpec.describe OpenAI::Client do
+  describe "#responses" do
+    context "with messages", :vcr do
+      let(:model) { "gpt-4o" }
+      let(:input) { "Hello!" }
+      let(:stream) { false }
+      let(:uri_base) { nil }
+      let(:response) do
+        OpenAI::Client.new({ uri_base: uri_base }).responses(
+          parameters: parameters
+        )
+      end
+      let(:parameters) { { model: model, input: input, stream: stream } }
+      let(:content) { response.dig("output", 0, "content", 0, "text") }
+      let(:provider) { nil }
+      let(:cassette) do
+        "#{"#{provider}_" if provider}#{model} #{'streamed' if stream} ResponsesAPI responses".downcase
+      end
+
+
+      it "succeeds" do
+        VCR.use_cassette(cassette) do
+          expect(content.split.empty?).to eq(false)
+        end
+      end
+
+      context "with followup message" do
+        let(:input) { "Hello! My name is Szymon." }
+        let(:input_followup) { "Remind me, what is my name?" }
+        let(:previous_response_id) { response["id"] }
+        let(:followup_parameters) do
+          { model: model, input: input_followup, stream: stream, previous_response_id: previous_response_id }
+        end
+        let(:followup_response) do
+          OpenAI::Client.new({ uri_base: uri_base }).responses(
+            parameters: followup_parameters
+          )
+        end
+        let(:followup_content) { followup_response.dig("output", 0, "content", 0, "text") }
+        let(:cassette) do
+          "#{"#{provider}_" if provider}#{model} #{'streamed' if stream} with followup message ResponsesAPI responses".downcase
+        end
+
+        it "remembers the conversation history" do
+          VCR.use_cassette(cassette) do
+            expect(content).to eq("Hello, Szymon! How can I assist you today?")
+            expect(followup_content).to eq("Your name is Szymon.")
+          end
+        end
+      end
+
+      context "with a tool call" do
+        let(:parameters) do
+          {
+            model: model,
+            input: input,
+            stream: stream,
+            tools: tools
+          }
+        end
+        let(:tools) do
+          [
+            {
+              "type" => "function",
+              "name" => "get_current_weather",
+              "description" => "Get the current weather in a given location",
+              "parameters" =>
+                {
+                  "type" => "object",
+                  "properties" => {
+                    "location" => {
+                      "type" => "string",
+                      "description" => "The geographic location to get the weather for"
+                    }
+                  },
+                  "required" => ["location"]
+                }
+              }
+          ]
+        end
+
+        context "with a valid message" do
+          let(:cassette) { "#{model} valid tool call ResponsesAPI responses".downcase }
+          let(:input) { "What is the weather like in the Peak District?" }
+
+          it "succeeds" do
+            VCR.use_cassette(cassette) do
+              expect(response.dig("output", 0, "type")).to eq("function_call")
+              expect(response.dig("output", 0, "name")).to eq("get_current_weather")
+              expect(response.dig("output", 0, "arguments")).to include("Peak District")
+            end
+          end
+        end
+      end
+
+      describe "streaming" do
+        let(:chunks) { [] }
+        let(:stream) do
+          proc do |chunk, _bytesize|
+            chunks << chunk
+          end
+        end
+
+        it "succeeds" do
+          VCR.use_cassette(cassette) do
+            response
+            output_text = chunks
+              .select { |chunk| chunk["type"] == "response.output_text.delta" }
+              .map { |chunk| chunk["delta"] }
+              .join
+
+            expect(output_text).to eq("Hi there! How can I assist you today?")
+          end
+        end
+
+        context "with an object with a call method" do
+          let(:cassette) { "#{model} streamed ResponsesAPI responses without proc".downcase }
+          let(:stream) do
+            Class.new do
+              attr_reader :chunks
+
+              def initialize
+                @chunks = []
+              end
+
+              def call(chunk)
+                @chunks << chunk
+              end
+            end.new
+          end
+
+          it "succeeds" do
+            VCR.use_cassette(cassette) do
+              response
+              output_text = stream.chunks
+                .select { |chunk| chunk["type"] == "response.output_text.delta" }
+                .map { |chunk| chunk["delta"] }
+                .join
+
+              expect(output_text).to eq("Hi there! How can I assist you today?")
+            end
+          end
+        end
+
+        context "with an object without a call method" do
+          let(:stream) { Object.new }
+
+          it "raises an error" do
+            VCR.use_cassette(cassette) do
+              expect { response }.to raise_error(ArgumentError)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Add support for OpenAI Responses API

This PR adds support for OpenAI's Responses API, which is their most advanced interface for generating model responses. The API supports text and image inputs with text outputs, and allows for stateful interactions using previous response IDs.

## Features added:
- Basic client method for making requests to `/responses` endpoint
- Support for follow-up messages (similar to the former threads functionality in the Assistant API)
- Tool calling functionality
- Streaming capability with both proc and callable object support
- Comprehensive test coverage with VCR cassettes

## Documentation:
- Added Responses API section to the README with examples for:
  - Basic usage
  - Follow-up messages 
  - Tool calls
  - Streaming

This implementation follows the same patterns used throughout the rest of the gem for consistency.

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
