### PR TITLE
Enable newly added purposes on Files API

### DIFF
--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -6,6 +6,7 @@ module OpenAI
       fine-tune
       vision
       user_data
+      evals
     ].freeze
 
     def initialize(client:)


### PR DESCRIPTION
OpenAI now supports `user_data` as an allowable purpose; updating the library to permit it. https://platform.openai.com/docs/api-reference/files/create#files-create-purpose

As it stands, attempting to upload a document using this purpose returns an error:
```
.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ruby-openai-7.4.0/lib/openai/files.rb:59:in `validate': `purpose` must be one of `assistants,batch,fine-tune,vision` (ArgumentError)

        raise ArgumentError, "`purpose` must be one of `#{PURPOSES.join(',')}`"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from .rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ruby-openai-7.4.0/lib/openai/files.rb:22:in `upload'
```

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
