### PR TITLE
Fix ruby warning: * interpreted as argument prefix

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -5,7 +5,7 @@ module OpenAI
     SENSITIVE_ATTRIBUTES = %i[@access_token @admin_token @organization_id @extra_headers].freeze
     CONFIG_KEYS = %i[access_token admin_token api_type api_version extra_headers
                      log_errors organization_id request_timeout uri_base].freeze
-    attr_reader *CONFIG_KEYS, :faraday_middleware
+    attr_reader(*CONFIG_KEYS, :faraday_middleware)
     attr_writer :access_token
 
     def initialize(config = {}, &faraday_middleware)


### PR DESCRIPTION
I see this warning on MRI 3.3:

```console
ruby/3.3.7/lib/ruby/gems/3.3.0/gems/ruby-openai-6.3.1/lib/openai/client.rb:14: warning: `*' interpreted as argument prefix
```

Using explicit parenthesis fixes the issue.

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
