### PR TITLE
handle parsing for error when chunked

### DIFF
--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -73,10 +73,10 @@ module OpenAI
             raise_error = Faraday::Response::RaiseError.new
             raise_error.on_complete(env.merge(body: parsed_error))
           end
-        end
-
-        parser.feed(chunk) do |_type, data|
-          user_proc.call(JSON.parse(data)) unless data == "[DONE]"
+        else
+          parser.feed(chunk) do |_type, data|
+            user_proc.call(JSON.parse(data)) unless data == "[DONE]"
+          end
         end
       end
     end


### PR DESCRIPTION
## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

So I based this off of https://github.com/alexrudall/ruby-openai/pull/480 which seems like it might be abandoned at this point. I copy-pasted the spec minus a minor fix for splitting the json into 2 chunks (it was missing a character in the 2nd chunk).

The approach taken here _assumes the error is parsable json_. We accumulate the chunks until the message is parsable, _then_ we raise an error. I don't really know enough about SSE/streaming to know whether this is definitely a bad idea but none of the existing specs broke so I'm hoping it's acceptable.

Not sure what would happen if, let's say, the stream disconnects midway so we never get the completed error message. I'm guessing in that case a different type of error (related to connection/streaming) will surface instead of the original error, which is probably ok? 

Or if the error is never parsable - then possibly the whole thing fails silently? 

Let me know your thoughts please. 