### PR TITLE
Fix for Faraday::ParsingError when retrieving the content of a file from OpenAI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
 
+Metrics/ModuleLength:
+  Max: 150
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -34,7 +34,7 @@ module OpenAI
     end
 
     def content(id:)
-      @client.get(path: "/files/#{id}/content")
+      @client.get_file(path: "/files/#{id}/content")
     end
 
     def delete(id:)

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -12,6 +12,12 @@ module OpenAI
       end&.body)
     end
 
+    def get_file(path:, parameters: nil)
+      parse_json(conn.get(uri(path: path), parameters) do |req|
+        req.headers = headers.merge({ "Accept" => "application/octet-stream" })
+      end&.body)
+    end
+
     def post(path:)
       parse_json(conn.post(uri(path: path)) do |req|
         req.headers = headers

--- a/spec/fixtures/cassettes/files_content.yml
+++ b/spec/fixtures/cassettes/files_content.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/octet-stream
       User-Agent:
       - Ruby
   response:

--- a/spec/fixtures/cassettes/files_fetch_image.yml
+++ b/spec/fixtures/cassettes/files_fetch_image.yml
@@ -14,7 +14,7 @@ http_interactions:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - "*/*"
+      - application/octet-stream
       User-Agent:
       - Ruby
   response:


### PR DESCRIPTION
## All Submissions:

Fix for Faraday::ParsingError when retrieving the content of a file from OpenAI.

Steps to reproduce (batch mode in openai, trying to retrieve the results after submitting a batch)
```
client = OpenAI::Client.new(access_token: ENV['OPENAI_API_KEY'])
output_file_id = "file-K1YqCx8oVZ1Fv3hPPWq23K" # Replace with your actual file ID containing JSONL rows
output_response = client.files.content(id: output_file_id)
```
On 8.1.0 main we get an error:
```
=> Faraday::ParsingError parsing Error
JSON::Ext::Parser#parse': unexpected token at
```
(this is because faraday_middleware tries to parse the response content as JSON - it might be a Faraday 1.x problem only ?)

Note: I believe this comment refers to the same issue : https://github.com/alexrudall/ruby-openai/pull/544#issuecomment-2847718657

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
