### PR TITLE
Handle OpenAI::Files request parameters

### DIFF
--- a/lib/openai/files.rb
+++ b/lib/openai/files.rb
@@ -29,12 +29,12 @@ module OpenAI
       file.close if file.is_a?(File)
     end
 
-    def retrieve(id:)
-      @client.get(path: "/files/#{id}")
+    def retrieve(id:, parameters: {})
+      @client.get(path: "/files/#{id}", parameters: parameters)
     end
 
-    def content(id:)
-      @client.get(path: "/files/#{id}/content")
+    def content(id:, parameters: {})
+      @client.get(path: "/files/#{id}/content", parameters: parameters)
     end
 
     def delete(id:)


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

## Description

In my case, we use LiteLLM as main LLM provider.
I was aiming to use a Batches API via Azure provider, and to so, I have to manually pass additional parameters in LiteLLM API requests.

For example, in order to read file content via Files API, we use additional `provider` parameter.
```
def get_file_content(file_id:)
  client.files.content(id: file_id, parameters: { provider: 'azure' })
end
```

Currently we Monkey Patched OpenAI::Files module to handle parameters key, until appropriate changes will be merged or implemented.

