### PR TITLE
Handle file upload Mime content type (including jsonl extension)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 # Development dependencies. Not included in the publised gem.
 gem "byebug", "~> 11.1.3"
 gem "dotenv", "~> 2.8.1" # >= v3 will require removing support for Ruby 2.7 from CI.
+gem "mime-types", "~> 3.5"
 gem "rake", "~> 13.2.1"
 gem "rspec", "~> 3.13"
 gem "rubocop", "~> 1.74.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,9 @@ GEM
     json (2.10.2)
     language_server-protocol (3.17.0.4)
     lint_roller (1.1.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0604)
     multipart-post (2.3.0)
     parallel (1.26.3)
     parser (3.3.7.1)
@@ -87,6 +90,7 @@ PLATFORMS
 DEPENDENCIES
   byebug (~> 11.1.3)
   dotenv (~> 2.8.1)
+  mime-types (~> 3.5)
   rake (~> 13.2.1)
   rspec (~> 3.13)
   rubocop (~> 1.74.0)

--- a/lib/openai.rb
+++ b/lib/openai.rb
@@ -21,6 +21,7 @@ require_relative "openai/audio"
 require_relative "openai/version"
 require_relative "openai/batches"
 require_relative "openai/usage"
+require_relative "openai/mime_types"
 
 module OpenAI
   class Error < StandardError; end

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -87,11 +87,9 @@ module OpenAI
         # Faraday::UploadIO does not require a path, so we will pass it
         # only if it is available. This allows StringIO objects to be
         # passed in as well.
-        path = value.respond_to?(:path) ? value.path : nil
-        # Doesn't seem like OpenAI needs mime_type yet, so not worth
-        # the library to figure this out. Hence the empty string
-        # as the second argument.
-        Faraday::UploadIO.new(value, "", path)
+        return Faraday::UploadIO.new(value, "", nil) unless value.respond_to?(:path)
+
+        Faraday::UploadIO.new(value, mime_type_for(value.path), value.path)
       end
     end
 
@@ -107,6 +105,10 @@ module OpenAI
 
       req.headers = headers
       req.body = req_parameters.to_json
+    end
+
+    def mime_type_for(path)
+      MIME::Types.of(path).first.to_s
     end
   end
 end

--- a/lib/openai/mime_types.rb
+++ b/lib/openai/mime_types.rb
@@ -1,0 +1,17 @@
+require "mime/types"
+
+module OpenAI
+  module MimeTypes
+    REGISTER_MIME_TYPES = { "jsonl" => "application/json" }.freeze
+
+    def self.register
+      REGISTER_MIME_TYPES.each do |register_type, mime_type|
+        next if MIME::Types.of(register_type).any?
+
+        MIME::Types[mime_type].first.add_extensions(register_type)
+      end
+    end
+  end
+end
+
+OpenAI::MimeTypes.register


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

## Related Open Issues
https://github.com/alexrudall/ruby-openai/issues/521

## Description
The problem was initially raised out of `jsonl` file uploading, which led to error below:
```
# OpenAI HTTP Error (spotted in ruby-openai 7.1.0): {"error"=>{"code"=>"invalidPayload", "message"=>"The file has no or an empty content type specified."}}
# Faraday::BadRequestError: the server responded with status 400
```
Previously there was empty content-type hardcoded value while sending http parameters - https://github.com/alexrudall/ruby-openai/blob/main/lib/openai/http.rb#L91-L94

In order to fix an issue with `jsonl` file, we were patching the gem in our project, writing something like that:
```
def multipart_parameters(parameters)
  parameters&.transform_values do |value|
    next value unless value.respond_to?(:close) # File or IO object.

    # Faraday::UploadIO does not require a path, so we will pass it
    # only if it is available. This allows StringIO objects to be
    # passed in as well.
    path = value.respond_to?(:path) ? value.path : nil

    mime_type = path&.end_with?('.jsonl') ? Mime[:json].to_s : ''
    Faraday::UploadIO.new(value, mime_type, path)
  end
end
```

In scope of this PR I'm trying to handle this logic via usage of `MIME::Types` (`mime-types` gem).
In order to `jsonl` file to be recognised as application/json content type we had to manually register it upon project building, that's why I've created `OpenAI::MimeTypes` module, where we also call .register to register some custom types (might be extended in future).

I've tested it locally, sending jsonl file for batch purposes - it've worked as expected.

