### PR TITLE
Fix `ArgumentError` in `Stream#call` with Faraday 2.1.0

### DIFF
--- a/lib/openai/stream.rb
+++ b/lib/openai/stream.rb
@@ -17,7 +17,7 @@ module OpenAI
         end
     end
 
-    def call(chunk, _bytes, env)
+    def call(chunk, _bytes, env = nil)
       handle_http_error(chunk: chunk, env: env) if env && env.status != 200
 
       parser.feed(chunk) do |event, data|

--- a/spec/openai/client/stream_spec.rb
+++ b/spec/openai/client/stream_spec.rb
@@ -106,6 +106,26 @@ RSpec.describe OpenAI::Stream do
           CHUNK
         end
       end
+
+      context "when called with only 2 arguments (like Faraday 2.1.0)" do
+        it "handles the call without env parameter" do
+          expect(user_proc).to receive(:call)
+            .with(
+              JSON.parse('{"foo": "bar"}'),
+              "event.test"
+            )
+
+          # Faraday 2.1.0 calls with only (chunk, size), not (chunk, size, env)
+          expect do
+            stream.call(<<~CHUNK, bytes)
+              event: event.test
+              data: { "foo": "bar" }
+
+              #
+            CHUNK
+          end.not_to raise_error
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #617 

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

## Problem

After upgrading from ruby-openai 8.1 to 8.2, users encountered an `ArgumentError` when using streaming with Faraday 2.1.0:

  `ArgumentError: wrong number of arguments (given 2, expected 3)`

  The error occurs because Faraday 2.1.0 calls the `on_data` callback with only 2 arguments (`chunk`, `size`), but the new `Stream#call` method expects 3 arguments (`chunk`, `_bytes`, `env`).

## Root Cause

  In version 8.2.0, streaming functionality was refactored from an inline Proc in `HTTP#to_json_stream` to a dedicated`Stream` class (PR #589). This introduced a breaking change:

  **Before 8.2.0 (worked fine):**
  - Used a Proc: `proc do |chunk, _bytes, env|`
  - Ruby Procs are flexible with argument counts - when called with
  fewer arguments, missing parameters become `nil`
  - Faraday calling with 2 arguments worked without errors

  **After 8.2.0 (breaks):**
  - Uses a method: `def call(chunk, _bytes, env)`
  - Ruby methods strictly enforce argument counts
  - Faraday calling with 2 arguments raises `ArgumentError`

  ## Faraday's Behavior

  In `faraday-net_http` v2.1.0, the callback is invoked with only 2 parameters:
  ```ruby
  # https://github.com/lostisland/faraday-net_http/blob/v2.1.0/lib/faraday/adapter/net_http.rb#L112
  env[:request].on_data.call(chunk, size)

  ## Solution

  Make the env parameter optional with a default value of nil:

  ```def call(chunk, _bytes, env = nil)```

  This maintains backward compatibility with different Faraday versions while preserving the same functionality.

