### PR TITLE
adding back compatibility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ and require with:
 require "openai"
 ```
 
+## Compatibility with offical OpenAI library
+
+OpenAI now publishes their own [Ruby client library](https://github.com/openai/openai-ruby), which uses the same namespace as this one. If you are working with a codebase that uses both, you can require this one with this alternate path to avoid collisions:
+
+```ruby
+require "ruby/openai"
+```
+
 ## How to use
 
 - Get your API key from [https://platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys)

--- a/lib/openai/compatibility.rb
+++ b/lib/openai/compatibility.rb
@@ -1,0 +1,9 @@
+module Ruby
+  module OpenAI
+    VERSION = ::OpenAI::VERSION
+
+    Error = ::OpenAI::Error
+    ConfigurationError = ::OpenAI::ConfigurationError
+    Configuration = ::OpenAI::Configuration
+  end
+end

--- a/lib/ruby/openai.rb
+++ b/lib/ruby/openai.rb
@@ -1,1 +1,2 @@
 require_relative "../openai"
+require_relative "../openai/compatibility"

--- a/spec/compatibility_spec.rb
+++ b/spec/compatibility_spec.rb
@@ -1,0 +1,35 @@
+require "ruby/openai"
+
+RSpec.describe "compatibility" do
+  context "for moved constants" do
+    describe "::Ruby::OpenAI::VERSION" do
+      it "is mapped to ::OpenAI::VERSION" do
+        expect(Ruby::OpenAI::VERSION).to eq(OpenAI::VERSION)
+      end
+    end
+
+    describe "::Ruby::OpenAI::Error" do
+      it "is mapped to ::OpenAI::Error" do
+        expect(Ruby::OpenAI::Error).to eq(OpenAI::Error)
+        expect(Ruby::OpenAI::Error.new).to be_a(OpenAI::Error)
+        expect(OpenAI::Error.new).to be_a(Ruby::OpenAI::Error)
+      end
+    end
+
+    describe "::Ruby::OpenAI::ConfigurationError" do
+      it "is mapped to ::OpenAI::ConfigurationError" do
+        expect(Ruby::OpenAI::ConfigurationError).to eq(OpenAI::ConfigurationError)
+        expect(Ruby::OpenAI::ConfigurationError.new).to be_a(OpenAI::ConfigurationError)
+        expect(OpenAI::ConfigurationError.new).to be_a(Ruby::OpenAI::ConfigurationError)
+      end
+    end
+
+    describe "::Ruby::OpenAI::Configuration" do
+      it "is mapped to ::OpenAI::Configuration" do
+        expect(Ruby::OpenAI::Configuration).to eq(OpenAI::Configuration)
+        expect(Ruby::OpenAI::Configuration.new).to be_a(OpenAI::Configuration)
+        expect(OpenAI::Configuration.new).to be_a(Ruby::OpenAI::Configuration)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #625. Adds back the compatibility layer that allows this library to be included via `require "ruby/openai"` so that it can cohabitate with OpenAI's official client library for Ruby. Please let me know if I missed anything here.

## All Submissions:

* [X] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
