### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ client.chat(
 
 #### Vision
 
-You can use the GPT-4 Vision model to generate a description of an image:
+You can use the GPT-4o as a Vision model to generate a description of an image:
 
 ```ruby
 messages = [
@@ -471,7 +471,7 @@ messages = [
 ]
 response = client.chat(
   parameters: {
-    model: "gpt-4-vision-preview", # Required.
+    model: "gpt-4o", # Required.
     messages: [{ role: "user", content: messages}], # Required.
   }
 )


### PR DESCRIPTION
gpt-4-vision-preview was depreciated 12-06-2024 they recommend using gpt-4o instead.
https://platform.openai.com/docs/deprecations

The existing example did not work, returning OpenAI HTTP Error "code"=>"model_not_found"
the same example using gpt-4o worked as expected.

