### PR TITLE
Fix: Buffer complete error body in streaming mode before raising

### DIFF
--- a/lib/openai/stream.rb
+++ b/lib/openai/stream.rb
@@ -18,7 +18,31 @@ module OpenAI
     end
 
     def call(chunk, _bytes, env = nil)
-      handle_http_error(chunk: chunk, env: env) if env && env.status != 200
+      if env && env.status != 200 && @error_env.nil?
+        @error_body = +""
+        @error_env = env
+      end
+
+      if @error_env
+        @error_body << chunk
+
+        # Buffer error chunks until we have complete JSON, then raise with
+        # the full body. Without this, only the first chunk (often just "{")
+        # would be captured, losing the actual API error message.
+        parsed = try_parse_json(@error_body)
+        unless parsed.is_a?(String)
+          raise_error = Faraday::Response::RaiseError.new
+          raise_error.on_complete(@error_env.merge(body: parsed))
+        end
+
+        # Safety valve: raise with raw body if we've buffered too much
+        if @error_body.bytesize > 65_536
+          raise_error = Faraday::Response::RaiseError.new
+          raise_error.on_complete(@error_env.merge(body: @error_body))
+        end
+
+        return
+      end
 
       parser.feed(chunk) do |event, data|
         next if data == DONE
@@ -35,11 +59,6 @@ module OpenAI
     private
 
     attr_reader :user_proc, :parser, :user_proc_arity
-
-    def handle_http_error(chunk:, env:)
-      raise_error = Faraday::Response::RaiseError.new
-      raise_error.on_complete(env.merge(body: try_parse_json(chunk)))
-    end
 
     def try_parse_json(maybe_json)
       JSON.parse(maybe_json)


### PR DESCRIPTION
## Problem

When using streaming mode (`stream: <proc>`), API error responses (e.g. 400 Bad Request) lose their response body. The error raised by Faraday only contains the generic message like:

```
the server responded with status 400 for POST https://api.openai.com/v1/chat/completions
```

...instead of the actual error from OpenAI, e.g.:

```
Invalid schema for function 'create_chart': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'title'.
```

This makes debugging tool schema issues, message format problems, and other 400-class errors extremely difficult.

## Root Cause

In `Stream#call`, `handle_http_error` is called on the **first chunk** of the response body. For streaming HTTP, the first chunk is often just `{` — a single byte — because the response body is delivered in multiple chunks by net/http.

Since `handle_http_error` raises immediately with only this first chunk, `try_parse_json("{")` fails and the error body is just the raw string `{`. The actual error message from OpenAI is in subsequent chunks that are never read.

## Fix

Instead of raising immediately on the first chunk, buffer all error chunks until `try_parse_json` succeeds (returns a parsed Hash/Array rather than a raw String). Then raise with the complete body.

Key detail: `env` is passed on **every** chunk call by Faraday's `stream_response` (not just the first), so the buffer initialization is guarded by `@error_env.nil?` to prevent resetting on each chunk.

Includes a 64KB safety valve — if the accumulated body exceeds this without parsing as valid JSON, we raise with the raw body to avoid silently swallowing errors.

## Testing

Tested against OpenAI's chat completions API with deliberately invalid tool schemas. Before this fix, the error message was:

```
the server responded with status 400 for POST https://api.openai.com/v1/chat/completions
```

After this fix:

```
Invalid schema for function 'create_chart': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Missing 'title'.
```