### PR TITLE
Reuse Faraday connection across requests

### DIFF
--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -113,6 +113,12 @@ module OpenAI
       @api_type&.to_sym == :azure
     end
 
+    def initialize_dup(original)
+      super
+      @connection = nil
+      @multipart_connection = nil
+    end
+
     def admin
       unless admin_token
         e = "You must set an OPENAI_ADMIN_TOKEN= to use administrative endpoints:\n\n  https://platform.openai.com/settings/organization/admin-keys"

--- a/lib/openai/client.rb
+++ b/lib/openai/client.rb
@@ -115,8 +115,8 @@ module OpenAI
 
     def initialize_dup(original)
       super
-      @connection = nil
-      @multipart_connection = nil
+      @conn = nil
+      @multipart_conn = nil
     end
 
     def admin

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -57,9 +57,9 @@ module OpenAI
 
     def conn(multipart: false)
       if multipart
-        @multipart_connection ||= build_connection(multipart: true)
+        @multipart_conn ||= build_connection(multipart: true)
       else
-        @connection ||= build_connection
+        @conn ||= build_connection
       end
     end
 

--- a/lib/openai/http.rb
+++ b/lib/openai/http.rb
@@ -56,6 +56,14 @@ module OpenAI
     end
 
     def conn(multipart: false)
+      if multipart
+        @multipart_connection ||= build_connection(multipart: true)
+      else
+        @connection ||= build_connection
+      end
+    end
+
+    def build_connection(multipart: false)
       connection = Faraday.new do |f|
         f.options[:timeout] = @request_timeout
         f.request(:multipart) if multipart


### PR DESCRIPTION
## Summary

- Cache the Faraday connection object on the client instance instead of creating a new one per HTTP request
- Enables TCP keep-alive and avoids rebuilding the middleware stack on every call
- Duped clients (via `beta`/`admin`) get their own fresh connections through `initialize_dup`

Benchmark against live OpenAI API (10x `models.list` after warmup):

```
WITHOUT connection reuse: 7.352s (735.2ms avg)
WITH connection reuse:    6.365s (636.5ms avg)
~13% faster
```

## Test plan

- [x] All 155 existing specs pass
- [x] Verified connection object is reused (same `object_id` across calls)
- [x] Verified `dup` creates a fresh connection (for `beta`/`admin`)
- [x] Benchmarked against live API with warmup to confirm real improvement