### PR TITLE
Fix streaming error handling to be compatible with middleware stack

### DIFF
--- a/lib/openai/stream.rb
+++ b/lib/openai/stream.rb
@@ -18,7 +18,7 @@ module OpenAI
     end
 
     def call(chunk, _bytes, env = nil)
-      handle_http_error(chunk: chunk, env: env) if env && env.status != 200
+      return accumulate_error_body(chunk, env) if env&.status && env.status != 200
 
       parser.feed(chunk) do |event, data|
         next if data == DONE
@@ -36,15 +36,12 @@ module OpenAI
 
     attr_reader :user_proc, :parser, :user_proc_arity
 
-    def handle_http_error(chunk:, env:)
-      raise_error = Faraday::Response::RaiseError.new
-      raise_error.on_complete(env.merge(body: try_parse_json(chunk)))
-    end
+    def accumulate_error_body(chunk, env)
+      @error_body = (@error_body || "") + chunk
+      return if @error_body_callback_set
 
-    def try_parse_json(maybe_json)
-      JSON.parse(maybe_json)
-    rescue JSON::ParserError
-      maybe_json
+      env.response.on_complete { |e| e.body = @error_body }
+      @error_body_callback_set = true
     end
   end
 end

--- a/spec/fixtures/cassettes/mocks/gpt-3_5-turbo_streamed_chat_with_rate_limit_error.yml
+++ b/spec/fixtures/cassettes/mocks/gpt-3_5-turbo_streamed_chat_with_rate_limit_error.yml
@@ -1,0 +1,36 @@
+---
+http_interactions:
+  - request:
+      method: post
+      uri: https://api.openai.com/v1/chat/completions
+      body:
+        encoding: UTF-8
+        string: '{"model":"gpt-3.5-turbo","messages":[{"role":"user","content":"Hello!"}],"stream":true}'
+      headers:
+        Content-Type:
+          - application/json
+        Authorization:
+          - Bearer <OPENAI_ACCESS_TOKEN>
+        Accept-Encoding:
+          - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+        Accept:
+          - "*/*"
+        User-Agent:
+          - Ruby
+    response:
+      status:
+        code: 429
+        message: Too Many Requests
+      headers:
+        Date:
+          - Mon, 14 Aug 2023 15:02:13 GMT
+        Content-Type:
+          - application/json
+        X-Mock-Retry-After:
+          - "42"
+      body:
+        encoding: UTF-8
+        string: '{"error":{"message":"Mock rate limit error","type":"mock","param":null,"code":"rate_limit_exceeded"}}'
+    recorded_at: Mon, 14 Aug 2023 15:02:13 GMT
+
+recorded_with: VCR 6.1.0

--- a/spec/openai/client/chat_spec.rb
+++ b/spec/openai/client/chat_spec.rb
@@ -199,6 +199,53 @@ RSpec.describe OpenAI::Client do
             end
           end
 
+          context "with a custom middleware handling rate limit errors" do
+            let(:cassette) { "mocks/#{model} streamed chat with rate limit error".downcase }
+
+            rate_limit_error = Class.new(StandardError) do
+              attr_reader :retry_after, :error_body
+
+              define_method(:initialize) do |retry_after:, error_body:|
+                @retry_after = retry_after
+                @error_body = error_body
+                super("Rate limited, retry after #{retry_after}s")
+              end
+            end
+
+            rate_limit_middleware = Class.new(Faraday::Middleware) do
+              define_method(:on_complete) do |env|
+                return unless env.status == 429
+
+                raise rate_limit_error.new(
+                  retry_after: env.response_headers["x-mock-retry-after"],
+                  error_body: JSON.parse(env.body)
+                )
+              end
+            end
+
+            it "raises the custom error with rate limit details" do
+              client = OpenAI::Client.new do |f|
+                f.use rate_limit_middleware
+              end
+
+              VCR.use_cassette(cassette, record: :none) do
+                client.chat(parameters: parameters)
+              rescue rate_limit_error => e
+                expect(e.retry_after).to eq("42")
+                expect(e.error_body).to eq({
+                                             "error" => {
+                                               "message" => "Mock rate limit error",
+                                               "type" => "mock",
+                                               "param" => nil,
+                                               "code" => "rate_limit_exceeded"
+                                             }
+                                           })
+              else
+                raise "Expected to raise custom rate limit error"
+              end
+            end
+          end
+
           context "with an error response without a JSON body" do
             let(:cassette) { "mocks/#{model} streamed chat with error response".downcase }
 

--- a/spec/openai/client/stream_spec.rb
+++ b/spec/openai/client/stream_spec.rb
@@ -107,6 +107,30 @@ RSpec.describe OpenAI::Stream do
         end
       end
 
+      context "when the response status is not 200" do
+        let(:error_env) do
+          Faraday::Env.new.tap do |env|
+            env.status = 401
+            env.response = Faraday::Response.new
+          end
+        end
+
+        it "does not call the user proc" do
+          expect(user_proc).not_to receive(:call)
+
+          stream.call('{"error": "unauthorized"}', bytes, error_env)
+        end
+
+        it "preserves the error body for the middleware stack" do
+          stream.call('{"error": ', bytes, error_env)
+          stream.call('"unauthorized"}', bytes, error_env)
+
+          error_env.response.finish(error_env)
+
+          expect(error_env.body).to eq('{"error": "unauthorized"}')
+        end
+      end
+
       context "when called with only 2 arguments (like Faraday 2.1.0)" do
         it "handles the call without env parameter" do
           expect(user_proc).to receive(:call)


### PR DESCRIPTION
 When streaming, HTTP errors were handled by a detached instance of `Faraday::Response::RaiseError` from within the `on_data` callback. This caused issues with custom middleware never getting a chance to see or handle these errors.

The proposed fix is to instead of raising errors manually, we build the raw body for the registered middleware to react on.

The original behavior was first introduced in https://github.com/alexrudall/ruby-openai/pull/344

#591 and #635 are touching the issue a bit, but those are focusing on fixing the problem described in #479

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x]  Have you added an explanation of what your changes do and why you'd like us to include them?
