### PR TITLE
Docs/Update docs with best practices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
+title: "[Bug]: "
+labels: bug
 assignees: ''
 
 ---
@@ -19,6 +19,14 @@ Steps to reproduce the behavior:
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
+
+**Versions**
+- ruby-openai:
+- Ruby:
+- Faraday:
+
+**Security note**
+If this report may involve exposure of tokens, request data, response data, files, or logs, please stop and use GitHub private vulnerability reporting instead of opening a public issue.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
+title: "[Feature]: "
+labels: enhancement
 assignees: ''
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Add public support, end-of-life, and migration documentation.
+- Add clearer issue template labels and bug report version fields.
+
 ## [8.3.0] - 2025-08-29
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,41 @@
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/alexrudall/ruby-openai. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/alexrudall/ruby-openai/blob/main/CODE_OF_CONDUCT.md).
+Bug reports, feature requests, and pull requests are welcome on GitHub at <https://github.com/alexrudall/ruby-openai>.
+
+This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/alexrudall/ruby-openai/blob/main/CODE_OF_CONDUCT.md).
+
+## Reporting Issues
+
+Before opening a new issue, please search existing issues and pull requests to see whether the problem has already been reported.
+
+For bugs, use the bug report template and include:
+
+- The ruby-openai version.
+- The Ruby version.
+- Relevant Faraday or dependency versions.
+- A minimal reproduction or code sample.
+- The expected behavior and actual behavior.
+
+For feature requests, use the feature request template and describe the OpenAI API endpoint or behavior you need.
+
+Please report suspected security vulnerabilities through GitHub private vulnerability reporting, not public issues. See `SECURITY.md`.
+
+## Issue Response Process
+
+Issues are triaged by the maintainer as time allows. The typical process is:
+
+1. Confirm whether the issue is a bug, feature request, usage question, duplicate, or security concern.
+2. Ask for reproduction steps or logs when more information is needed.
+3. Prioritize regressions, security concerns, and widely affecting API compatibility issues.
+4. Accept a pull request or prepare a maintainer fix when the change is ready.
+5. Close the issue after the fix is released or the question is answered.
+
+## Pull Requests
+
+Pull requests should explain the problem being solved, the user-visible behavior change, and any compatibility impact.
+
+Run the test suite before opening a pull request when practical:
+
+```bash
+bundle exec rake
+```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,56 @@
+# Migration Guides
+
+This page collects maintainer-created migration notes for supported upgrade paths. For the complete release history, see `CHANGELOG.md`.
+
+## General Upgrade Process
+
+1. Upgrade to the latest patch or minor release within your current major version.
+2. Review the relevant major-version guide below.
+3. Update your application code and Gemfile.
+4. Run your test suite against the new version.
+5. Open a GitHub issue if a migration path is unclear or missing.
+
+## From 7.x to 8.x
+
+Version 8.0.0 includes breaking changes. Before upgrading, review the `8.0.0` entry in `CHANGELOG.md`.
+
+- Replace `require "ruby/openai"` with `require "openai"`.
+- Review Ruby compatibility before upgrading and run your test suite on the Ruby version used by your application.
+- HTTP responses are JSON-parsed when possible. If parsing fails, the raw response is returned.
+- Unknown file types no longer prevent file upload; the gem raises a warning instead.
+- Faraday 1 users no longer need ruby-openai to require `faraday/multipart` on their behalf.
+- The `OpenAI-Beta` header was removed from Batches API requests.
+
+## From 6.x to 7.x
+
+Version 7.0.0 included API coverage changes and one removed deprecated endpoint. Before upgrading, review the `7.0.0` and `7.0.1` entries in `CHANGELOG.md`.
+
+- The deprecated edits endpoint was removed.
+- Assistants-related APIs were updated for the v2 Assistants beta.
+- Batches support was added.
+- Base URI handling changed so `/v1/` is not added when the configured base URI already includes it.
+
+## From 5.x to 6.x
+
+Version 6.0.0 included several breaking changes. Before upgrading, review the `6.0.0` entry in `CHANGELOG.md`.
+
+- HTTP errors are raised as `Faraday::Error`, including while streaming.
+- Legacy Fine-tunes calls moved to the newer Fine-tuning jobs endpoints.
+- Deprecated Completions endpoints were removed in 6.0.0 and later restored as deprecated support in 6.5.0.
+- Streaming parameters are preserved instead of being replaced by a boolean.
+
+## From 4.x to 5.x
+
+Version 5.0.0 changed client configuration behavior. Before upgrading, review the `5.0.0` entry in `CHANGELOG.md`.
+
+- Each `OpenAI::Client` now holds its own configuration, enabling multi-tenant use.
+- Direct calls to class-level client methods may need to move to instance methods.
+- Audio methods moved from the client to the audio namespace: use `client.audio.translate` and `client.audio.transcribe`.
+
+## Older Versions
+
+For older major versions, use `CHANGELOG.md` as the source of truth for breaking changes. If an older upgrade path is important to you and the notes are not clear enough, please open an issue so the migration documentation can be improved.
+
+## Deprecation and Feature Removal
+
+Widely used deprecations and removals are documented in `CHANGELOG.md` and, for major releases, summarized here. When an upstream OpenAI API change forces a shorter deprecation window, the release notes should explain the reason and the migration path.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Stream GPT-5 chats with the Responses API, initiate Realtime WebRTC conversation
 
 - [Ruby OpenAI](#ruby-openai)
   - [Contents](#contents)
+  - [Project Policies](#project-policies)
   - [Installation](#installation)
     - [Bundler](#bundler)
     - [Gem install](#gem-install)
@@ -103,6 +104,13 @@ Stream GPT-5 chats with the Responses API, initiate Realtime WebRTC conversation
   - [Contributing](#contributing)
   - [License](#license)
   - [Code of Conduct](#code-of-conduct)
+
+## Project Policies
+
+- [Security policy](SECURITY.md)
+- [Support and end-of-life policy](SUPPORT.md)
+- [Migration guides](MIGRATION.md)
+- [Changelog](CHANGELOG.md)
 
 ## Installation
 
@@ -1951,9 +1959,19 @@ bundle exec ruby -e "Warning[:deprecated] = true; require 'rspec'; exit RSpec::C
 
 ## Release
 
-First run the specs without VCR so they actually hit the API. This will cost 2 cents or more. Set OPENAI_ACCESS_TOKEN and OPENAI_ADMIN_TOKEN in your environment.
+Ruby OpenAI follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+
+- Major releases may include breaking changes, removals, or support changes.
+- Minor releases add backwards-compatible functionality.
+- Patch releases fix backwards-compatible bugs or security issues.
+
+Before releasing, run the specs without VCR so they actually hit the API. This will cost 2 cents or more. Set OPENAI_ACCESS_TOKEN and OPENAI_ADMIN_TOKEN in your environment.
 
 Then update the version number in `version.rb`, update `CHANGELOG.md`, run `bundle install` to update Gemfile.lock, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+After the tag is pushed, publish or update the corresponding GitHub Release using the changelog entry.
+
+Release notes are published through GitHub Releases, git tags, RubyGems, and `CHANGELOG.md`. Security releases are identified in the changelog and release notes, and may also use GitHub Security Advisories. Major releases, security releases, and end-of-life notices may also be shared through the community channels linked at the top of this README.
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,9 +1,36 @@
 # Security Policy
 
-Thank you for helping us keep ruby-openai and any systems it interacts with secure.
+Thank you for helping keep Ruby OpenAI and the systems it interacts with secure.
+
+## Supported Versions
+
+Security fixes target the supported release line documented in `SUPPORT.md`.
 
 ## Reporting Security Issues
 
-The security of our systems and user data is our top priority. We appreciate the work of security researchers acting in good faith in identifying and reporting potential vulnerabilities.
+Please do not create a public GitHub issue for a suspected vulnerability.
 
-Any validated vulnerability in this functionality can be reported through Github - click on the [Security Tab](https://github.com/alexrudall/ruby-openai/security) and click "Report a vulnerability".
+Use GitHub private vulnerability reporting instead: open the repository [Security tab](https://github.com/alexrudall/ruby-openai/security) and click "Report a vulnerability".
+
+Helpful reports include:
+
+- A description of the vulnerability and impact.
+- Steps to reproduce, including affected ruby-openai versions.
+- Whether the issue can expose tokens, request data, response data, files, or logs.
+- Any known mitigations.
+
+## Response Process
+
+The maintainer will triage security reports privately, ask for more information when needed, and prioritize validated issues according to impact.
+
+For validated vulnerabilities, the project will aim to:
+
+1. Prepare a fix in private when public disclosure would increase user risk.
+2. Release a patched gem for the supported release line.
+3. Publish a GitHub Security Advisory and request a CVE when applicable.
+4. Identify affected versions, patched versions, and any available mitigations.
+5. State whether a backport is available for older release lines.
+
+## Backports and Mitigations
+
+Security fixes may be backported when practical, as described in `SUPPORT.md`. If a backport is not available, the security advisory or release notes will document the recommended upgrade path and any known mitigations.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,59 @@
+# Support Policy
+
+Ruby OpenAI is maintained by a single volunteer maintainer with help from community contributors. This policy sets clear expectations for supported versions, end-of-life status, and where users should ask for help.
+
+## Supported Versions
+
+Users should run the latest released version of the latest major release line whenever possible.
+
+| Release line | Status | Support |
+| --- | --- | --- |
+| 8.x | Supported | Bug fixes, compatibility updates, and security fixes. Use the latest 8.x patch or minor release. |
+| 7.x and earlier | End of life | No routine fixes. Users should upgrade to 8.x. Security reports may still receive advisory guidance. |
+
+This table is reviewed when each new major version is released.
+
+## Support Tiers
+
+- Supported: The current major release line. Receives bug fixes, compatibility updates, and security fixes.
+- Security-only transition: A previous major release line may receive security fixes only for a defined transition period when a new major version is released.
+- End of life: No fixes are planned. Users should migrate to a supported version.
+- Development: The `main` branch and unreleased commits are for testing and development. Production users should depend on released gems.
+
+## End-of-Life Process
+
+For future major releases, the project aims to:
+
+1. Document the support status of old and new release lines in this file, `CHANGELOG.md`, and release notes.
+2. Provide 3-6 months of notice before ending support for a previous major release line when practical for a small maintainer-led project.
+3. Encourage users to migrate to the supported major release line, or establish their own support solution if immediate migration is not possible.
+4. Announce end-of-life events through the same channels used for releases.
+
+Shorter timelines may be necessary when an upstream API change, dependency issue, or security issue requires faster action. In those cases, the reason will be documented in the release notes.
+
+## Release and Announcement Channels
+
+Release information is published through:
+
+- GitHub Releases and git tags: <https://github.com/alexrudall/ruby-openai/releases>
+- RubyGems: <https://rubygems.org/gems/ruby-openai>
+- `CHANGELOG.md`: <https://github.com/alexrudall/ruby-openai/blob/main/CHANGELOG.md>
+
+Major releases, security releases, and end-of-life notices may also be shared through the community channels linked from the README.
+
+## Backports
+
+Routine bug fixes and feature work are not normally backported. They target the supported release line.
+
+Security fixes may be backported to a security-only release line when practical. If a backport is not provided, the release notes or security advisory will identify the affected versions and the supported upgrade path.
+
+## Getting Help
+
+- Bugs and regressions: Open a GitHub issue using the bug report template.
+- Feature requests and API coverage gaps: Open a GitHub issue using the feature request template.
+- Security issues: Use GitHub private vulnerability reporting from the repository Security tab.
+- General community help: Use the community channels linked from the README.
+
+## Third-Party Support Providers
+
+Ruby OpenAI does not currently list or endorse third-party migration assistance, long-term support, or security support providers. Providers may be considered in the future if they have a clear history and reputation for competent Ruby OpenAI support.

--- a/ruby-openai.gemspec
+++ b/ruby-openai.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/alexrudall/ruby-openai"
   spec.metadata["changelog_uri"] = "https://github.com/alexrudall/ruby-openai/blob/main/CHANGELOG.md"
+  spec.metadata["bug_tracker_uri"] = "https://github.com/alexrudall/ruby-openai/issues"
+  spec.metadata["documentation_uri"] = "https://github.com/alexrudall/ruby-openai#readme"
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["funding_uri"] = "https://github.com/sponsors/alexrudall"
 


### PR DESCRIPTION
## Summary

- Add public project policy links from the README to security, support/EOL, migration, and changelog docs.
- Add support/EOL and migration documentation covering support tiers, announcement channels, backports, migration paths, and third-party provider status.
- Expand security and contribution docs with issue triage, vulnerability reporting, advisory/CVE, mitigation, and backport expectations.
- Improve issue templates with default labels, bug report version fields, and security-reporting guidance.
- Add RubyGems metadata links for bug reports and documentation.

## Testing

- `bundle exec rubocop --cache false`
- `ruby -c ruby-openai.gemspec`
- `git diff --check`
- `env -u OPENAI_ACCESS_TOKEN -u OPENAI_ADMIN_TOKEN -u OPENAI_ORGANIZATION_ID bundle exec ruby -rdotenv -e 'module Dotenv; def self.load(*); {}; end; end; require "rspec/core"; exit RSpec::Core::Runner.run(["--format", "documentation", "--color", "--require", "spec_helper", "--pattern", "spec/**{,/*/**}/*_spec.rb"])'`

